### PR TITLE
Make tests with mock

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -42,4 +42,4 @@ jobs:
       run: |
         cd test
         # we run pytest without local data
-        pytest -m "not local_data"
+        pytest -m "not local_data and not request"

--- a/environment.yml
+++ b/environment.yml
@@ -10,6 +10,7 @@ dependencies:
     - geopandas
     - pyproj
     - requests
+    - requests-mock      
     - pandas
     - folium
     - langchain

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "geopandas",
     "pyproj",
     "requests",
+    "requests-mock",
     "pandas",
     "folium",
     "langchain",

--- a/src/climsight/environmental_functions.py
+++ b/src/climsight/environmental_functions.py
@@ -29,14 +29,21 @@ def fetch_biodiversity(lon, lat):
     }
     response = requests.get(gbif_api_url, params=params, timeout=3)
     biodiv = response.json()
-    biodiv_set = set()
+
+    biodiv_list = []
+    seen = set()  # This set will help in avoiding duplicates efficiently
+        
     if biodiv['results']:
         for record in biodiv['results']:
             if 'genericName' in record and record.get('taxonRank') != 'UNRANKED':
-                biodiv_set.add(record['genericName'])
-        biodiversity = ', '.join(list(biodiv_set))
+                generic_name = record['genericName']
+                if generic_name not in seen:  # Check if the name has already been added
+                    seen.add(generic_name)
+                    biodiv_list.append(generic_name)
+        biodiversity = ', '.join(biodiv_list)
     else:
         biodiversity = "Not known"
+        
     return biodiversity
  
  

--- a/test/config_test_environmental_functions.yml
+++ b/test/config_test_environmental_functions.yml
@@ -1,7 +1,7 @@
 test_location:
   lat: 52.5240
   lon: 13.3700
-  biodiv: 'Pristurus'
+  biodiv: 'Panellus, Piptoporus, Hordeum'
   promt_hazard_data:
     - year: 2002
       disastertype: storm
@@ -76,4 +76,1887 @@ test_location:
       disastertype: 'extreme temperature '
       latitude: 52.501532
       longitude: 13.40185
-
+expected_biodiv:
+  offset: 0
+  limit: 20
+  endOfRecords: false
+  count: 733
+  results:
+  - key: 1990330159
+    datasetKey: 032f1fbe-d21f-407d-be46-5cd1bb1ea397
+    publishingOrgKey: 61c539d8-47e0-4b82-875f-b95aad66dcd4
+    installationKey: dd8ffb07-5f02-4e70-b4cd-dbba0dfae83e
+    hostingOrganizationKey: b648db34-3bf9-45eb-a65b-8176a3c3be88
+    publishingCountry: US
+    protocol: DWC_ARCHIVE
+    lastCrawled: '2024-05-03T14:32:06.690+00:00'
+    lastParsed: '2024-05-03T14:33:08.719+00:00'
+    crawlId: 273
+    extensions: {}
+    basisOfRecord: PRESERVED_SPECIMEN
+    occurrenceStatus: PRESENT
+    taxonKey: 8931746
+    kingdomKey: 5
+    phylumKey: 34
+    classKey: 186
+    orderKey: 1499
+    familyKey: 4180
+    genusKey: 2526673
+    speciesKey: 8931746
+    acceptedTaxonKey: 8931746
+    scientificName: Panellus mitis (Pers.) Singer
+    acceptedScientificName: Panellus mitis (Pers.) Singer
+    kingdom: Fungi
+    phylum: Basidiomycota
+    order: Agaricales
+    family: Mycenaceae
+    genus: Panellus
+    species: Panellus mitis
+    genericName: Panellus
+    specificEpithet: mitis
+    taxonRank: SPECIES
+    taxonomicStatus: ACCEPTED
+    iucnRedListCategory: NE
+    decimalLatitude: 53.0
+    decimalLongitude: 13.0
+    continent: EUROPE
+    stateProvince: Mecklenburg-vorpommern
+    gadm:
+      level0:
+        gid: DEU
+        name: Germany
+      level1:
+        gid: DEU.4_1
+        name: Brandenburg
+      level2:
+        gid: DEU.4.12_1
+        name: Ostprignitz-Ruppin
+      level3:
+        gid: DEU.4.12.4_1
+        name: Lindow (Mark)
+    year: 2000
+    month: 1
+    day: 1
+    eventDate: '2000-01-01'
+    startDayOfYear: 1
+    endDayOfYear: 1
+    issues:
+    - GEODETIC_DATUM_ASSUMED_WGS84
+    - CONTINENT_DERIVED_FROM_COORDINATES
+    - TAXON_MATCH_TAXON_ID_IGNORED
+    - INSTITUTION_MATCH_NONE
+    modified: '2018-06-22T16:37:28.000+00:00'
+    lastInterpreted: '2024-05-03T14:33:08.719+00:00'
+    references: https://www.mycoportal.org/portal/collections/individual/index.php?occid=280204
+    license: http://creativecommons.org/publicdomain/zero/1.0/legalcode
+    isSequenced: false
+    identifiers:
+    - identifier: '280204'
+    media: []
+    facts: []
+    relations: []
+    isInCluster: false
+    recordedBy: "D. Kr\xFCger"
+    geodeticDatum: WGS84
+    class: Agaricomycetes
+    countryCode: DE
+    recordedByIDs: []
+    identifiedByIDs: []
+    gbifRegion: EUROPE
+    country: Germany
+    publishedByGbifRegion: NORTH_AMERICA
+    identifier: '280204'
+    recordNumber: '10913'
+    verbatimEventDate: 1/1/2000
+    http://unknown.org/recordID: 6a2f85c3-9767-4aee-944e-f972c53c28e7
+    county: Mecklenburg-Strelitz
+    locality: Neustrelitz, NANA
+    municipality: Neustrelitz
+    gbifID: '1990330159'
+    occurrenceID: 6a2f85c3-9767-4aee-944e-f972c53c28e7
+    taxonID: '186613'
+    catalogNumber: TENN-F-058396
+    institutionCode: TENN-F
+    rights: https://creativecommons.org/licenses/by-nc-nd/4.0/
+    http://unknown.org/recordEnteredBy: DK
+    collectionID: 97e2d271-3744-48a3-92b5-5a86afbfb01d
+    higherClassification: Fungi|Basidiomycota|Agaricomycotina|Agaricomycetes|Agaricomycetidae|Agaricales|Mycenaceae|Panellus
+  - key: 1990330206
+    datasetKey: 032f1fbe-d21f-407d-be46-5cd1bb1ea397
+    publishingOrgKey: 61c539d8-47e0-4b82-875f-b95aad66dcd4
+    installationKey: dd8ffb07-5f02-4e70-b4cd-dbba0dfae83e
+    hostingOrganizationKey: b648db34-3bf9-45eb-a65b-8176a3c3be88
+    publishingCountry: US
+    protocol: DWC_ARCHIVE
+    lastCrawled: '2024-05-03T14:32:06.690+00:00'
+    lastParsed: '2024-05-03T14:33:08.721+00:00'
+    crawlId: 273
+    extensions: {}
+    basisOfRecord: PRESERVED_SPECIMEN
+    occurrenceStatus: PRESENT
+    taxonKey: 9173916
+    kingdomKey: 5
+    phylumKey: 34
+    classKey: 186
+    orderKey: 1145
+    familyKey: 7619
+    genusKey: 2523631
+    speciesKey: 9819973
+    acceptedTaxonKey: 9819973
+    scientificName: Piptoporus betulinus (Bull.) P.Karst.
+    acceptedScientificName: Fomitopsis betulina (Bull.) B.K.Cui, M.L.Han & Y.C.Dai
+    kingdom: Fungi
+    phylum: Basidiomycota
+    order: Polyporales
+    family: Fomitopsidaceae
+    genus: Fomitopsis
+    species: Fomitopsis betulina
+    genericName: Piptoporus
+    specificEpithet: betulinus
+    taxonRank: SPECIES
+    taxonomicStatus: SYNONYM
+    iucnRedListCategory: NE
+    decimalLatitude: 53.0
+    decimalLongitude: 13.0
+    continent: EUROPE
+    stateProvince: Mecklenburg-vorpommern
+    gadm:
+      level0:
+        gid: DEU
+        name: Germany
+      level1:
+        gid: DEU.4_1
+        name: Brandenburg
+      level2:
+        gid: DEU.4.12_1
+        name: Ostprignitz-Ruppin
+      level3:
+        gid: DEU.4.12.4_1
+        name: Lindow (Mark)
+    year: 2000
+    month: 1
+    day: 1
+    eventDate: '2000-01-01'
+    startDayOfYear: 1
+    endDayOfYear: 1
+    issues:
+    - GEODETIC_DATUM_ASSUMED_WGS84
+    - CONTINENT_DERIVED_FROM_COORDINATES
+    - TAXON_MATCH_TAXON_ID_IGNORED
+    - INSTITUTION_MATCH_NONE
+    modified: '2018-06-22T16:37:28.000+00:00'
+    lastInterpreted: '2024-05-03T14:33:08.721+00:00'
+    references: https://www.mycoportal.org/portal/collections/individual/index.php?occid=280205
+    license: http://creativecommons.org/publicdomain/zero/1.0/legalcode
+    isSequenced: false
+    identifiers:
+    - identifier: '280205'
+    media: []
+    facts: []
+    relations: []
+    isInCluster: false
+    recordedBy: "D. Kr\xFCger"
+    geodeticDatum: WGS84
+    class: Agaricomycetes
+    countryCode: DE
+    recordedByIDs: []
+    identifiedByIDs: []
+    gbifRegion: EUROPE
+    country: Germany
+    publishedByGbifRegion: NORTH_AMERICA
+    identifier: '280205'
+    recordNumber: '10914'
+    verbatimEventDate: 1/1/2000
+    http://unknown.org/recordID: fd64762d-446b-4c78-904d-0a87a659cfd1
+    county: Mecklenburg-Strelitz
+    locality: Neustrelitz, Kiefernheide Forest (strelitzer Stadtforst), Rehwiese (lewitz
+      Moor)
+    municipality: Neustrelitz
+    gbifID: '1990330206'
+    occurrenceID: fd64762d-446b-4c78-904d-0a87a659cfd1
+    taxonID: '187541'
+    catalogNumber: TENN-F-058397
+    institutionCode: TENN-F
+    rights: https://creativecommons.org/licenses/by-nc-nd/4.0/
+    http://unknown.org/recordEnteredBy: DK
+    collectionID: 97e2d271-3744-48a3-92b5-5a86afbfb01d
+    higherClassification: Fungi|Basidiomycota|Agaricomycotina|Agaricomycetes|Agaricomycetidae|Polyporales|Fomitopsidaceae|Piptoporus
+  - key: 4525984287
+    datasetKey: 85796928-f762-11e1-a439-00145eb45e9a
+    publishingOrgKey: efc2ae40-9880-11da-89b4-b8a03c50a862
+    installationKey: 97dfec69-b198-43ba-a8fa-c5edbc04e324
+    hostingOrganizationKey: cace8d10-2646-11d8-a2da-b8a03c50a862
+    publishingCountry: NL
+    protocol: EML
+    lastCrawled: '2024-02-26T11:40:15.213+00:00'
+    lastParsed: '2024-02-26T12:47:26.520+00:00'
+    crawlId: 364
+    extensions:
+      http://purl.org/germplasm/germplasmTerm#GermplasmAccession:
+      - http://purl.org/germplasm/germplasmTerm#germplasmID: CGN00007
+        http://purl.org/germplasm/germplasmTerm#storageCondition: '-20'
+        http://purl.org/germplasm/germplasmTerm#biologicalStatus: '500'
+        http://purl.org/germplasm/germplasmTerm#germplasmIdentifier: CGN00007
+        http://purl.org/germplasm/germplasmTerm#safetyDuplicationInstituteID: DEU146
+        http://purl.org/germplasm/germplasmTerm#mlsStatus: '1'
+        http://www.w3.org/2003/01/geo/wgs84_pos#lat: '53'
+        http://www.w3.org/2003/01/geo/wgs84_pos#long: '13'
+        http://purl.org/germplasm/germplasmTerm#donorInstituteID: NLD078
+        http://purl.org/germplasm/germplasmTerm#breedingIdentifier: Lago
+    basisOfRecord: LIVING_SPECIMEN
+    occurrenceStatus: PRESENT
+    taxonKey: 4932619
+    kingdomKey: 6
+    phylumKey: 7707728
+    classKey: 196
+    orderKey: 1369
+    familyKey: 3073
+    genusKey: 2706050
+    speciesKey: 2706056
+    acceptedTaxonKey: 4932619
+    scientificName: Hordeum vulgare subsp. vulgare
+    acceptedScientificName: Hordeum vulgare subsp. vulgare
+    kingdom: Plantae
+    phylum: Tracheophyta
+    order: Poales
+    family: Poaceae
+    genus: Hordeum
+    species: Hordeum vulgare
+    genericName: Hordeum
+    specificEpithet: vulgare
+    infraspecificEpithet: vulgare
+    taxonRank: SUBSPECIES
+    taxonomicStatus: ACCEPTED
+    decimalLatitude: 53.0
+    decimalLongitude: 13.0
+    continent: EUROPE
+    gadm:
+      level0:
+        gid: DEU
+        name: Germany
+      level1:
+        gid: DEU.4_1
+        name: Brandenburg
+      level2:
+        gid: DEU.4.12_1
+        name: Ostprignitz-Ruppin
+      level3:
+        gid: DEU.4.12.4_1
+        name: Lindow (Mark)
+    issues:
+    - COUNTRY_DERIVED_FROM_COORDINATES
+    - CONTINENT_DERIVED_FROM_COORDINATES
+    - TAXON_MATCH_SCIENTIFIC_NAME_ID_IGNORED
+    - INSTITUTION_MATCH_NONE
+    lastInterpreted: '2024-02-26T12:47:26.520+00:00'
+    license: http://creativecommons.org/publicdomain/zero/1.0/legalcode
+    isSequenced: false
+    identifiers:
+    - identifier: 10.18730/12X57
+    media:
+    - references: https://cgngenis.wur.nl/accessiondetails/CGN00007
+    facts: []
+    relations: []
+    isInCluster: false
+    datasetID: NLD
+    geodeticDatum: WGS84
+    class: Liliopsida
+    countryCode: DE
+    recordedByIDs: []
+    identifiedByIDs: []
+    gbifRegion: EUROPE
+    country: Germany
+    publishedByGbifRegion: EUROPE
+    identifier: 10.18730/12X57
+    catalogNumber: CGN00007
+    vernacularName: barley
+    scientificNameID: Hordeum vulgare subsp. vulgare L.
+    institutionCode: NLD037
+    gbifID: '4525984287'
+    occurrenceID: 10.18730/12X57
+  - key: 4525980863
+    datasetKey: 85796928-f762-11e1-a439-00145eb45e9a
+    publishingOrgKey: efc2ae40-9880-11da-89b4-b8a03c50a862
+    installationKey: 97dfec69-b198-43ba-a8fa-c5edbc04e324
+    hostingOrganizationKey: cace8d10-2646-11d8-a2da-b8a03c50a862
+    publishingCountry: NL
+    protocol: EML
+    lastCrawled: '2024-02-26T11:40:15.213+00:00'
+    lastParsed: '2024-02-26T12:47:25.803+00:00'
+    crawlId: 364
+    extensions:
+      http://purl.org/germplasm/germplasmTerm#GermplasmAccession:
+      - http://purl.org/germplasm/germplasmTerm#germplasmID: CGN00226
+        http://purl.org/germplasm/germplasmTerm#storageCondition: '-20'
+        http://purl.org/germplasm/germplasmTerm#biologicalStatus: '400'
+        http://purl.org/germplasm/germplasmTerm#germplasmIdentifier: CGN00226
+        http://purl.org/germplasm/germplasmTerm#safetyDuplicationInstituteID: DEU146
+        http://purl.org/germplasm/germplasmTerm#mlsStatus: '1'
+        http://www.w3.org/2003/01/geo/wgs84_pos#lat: '53'
+        http://www.w3.org/2003/01/geo/wgs84_pos#long: '13'
+        http://purl.org/germplasm/germplasmTerm#donorInstituteID: NLD078
+        http://purl.org/germplasm/germplasmTerm#breedingIdentifier: Kuckuck 1961
+    basisOfRecord: LIVING_SPECIMEN
+    occurrenceStatus: PRESENT
+    taxonKey: 4932619
+    kingdomKey: 6
+    phylumKey: 7707728
+    classKey: 196
+    orderKey: 1369
+    familyKey: 3073
+    genusKey: 2706050
+    speciesKey: 2706056
+    acceptedTaxonKey: 4932619
+    scientificName: Hordeum vulgare subsp. vulgare
+    acceptedScientificName: Hordeum vulgare subsp. vulgare
+    kingdom: Plantae
+    phylum: Tracheophyta
+    order: Poales
+    family: Poaceae
+    genus: Hordeum
+    species: Hordeum vulgare
+    genericName: Hordeum
+    specificEpithet: vulgare
+    infraspecificEpithet: vulgare
+    taxonRank: SUBSPECIES
+    taxonomicStatus: ACCEPTED
+    decimalLatitude: 53.0
+    decimalLongitude: 13.0
+    continent: EUROPE
+    gadm:
+      level0:
+        gid: DEU
+        name: Germany
+      level1:
+        gid: DEU.4_1
+        name: Brandenburg
+      level2:
+        gid: DEU.4.12_1
+        name: Ostprignitz-Ruppin
+      level3:
+        gid: DEU.4.12.4_1
+        name: Lindow (Mark)
+    issues:
+    - COUNTRY_DERIVED_FROM_COORDINATES
+    - CONTINENT_DERIVED_FROM_COORDINATES
+    - TAXON_MATCH_SCIENTIFIC_NAME_ID_IGNORED
+    - INSTITUTION_MATCH_NONE
+    lastInterpreted: '2024-02-26T12:47:25.803+00:00'
+    license: http://creativecommons.org/publicdomain/zero/1.0/legalcode
+    isSequenced: false
+    identifiers:
+    - identifier: 10.18730/133Q*
+    media:
+    - references: https://cgngenis.wur.nl/accessiondetails/CGN00226
+    facts: []
+    relations: []
+    isInCluster: false
+    datasetID: NLD
+    geodeticDatum: WGS84
+    class: Liliopsida
+    countryCode: DE
+    recordedByIDs: []
+    identifiedByIDs: []
+    gbifRegion: EUROPE
+    country: Germany
+    publishedByGbifRegion: EUROPE
+    identifier: 10.18730/133Q*
+    catalogNumber: CGN00226
+    vernacularName: barley
+    scientificNameID: Hordeum vulgare subsp. vulgare L.
+    institutionCode: NLD037
+    gbifID: '4525980863'
+    occurrenceID: 10.18730/133Q*
+  - key: 4525980726
+    datasetKey: 85796928-f762-11e1-a439-00145eb45e9a
+    publishingOrgKey: efc2ae40-9880-11da-89b4-b8a03c50a862
+    installationKey: 97dfec69-b198-43ba-a8fa-c5edbc04e324
+    hostingOrganizationKey: cace8d10-2646-11d8-a2da-b8a03c50a862
+    publishingCountry: NL
+    protocol: EML
+    lastCrawled: '2024-02-26T11:40:15.213+00:00'
+    lastParsed: '2024-02-26T12:47:25.771+00:00'
+    crawlId: 364
+    extensions:
+      http://purl.org/germplasm/germplasmTerm#GermplasmAccession:
+      - http://purl.org/germplasm/germplasmTerm#germplasmID: CGN00228
+        http://purl.org/germplasm/germplasmTerm#storageCondition: '-20'
+        http://purl.org/germplasm/germplasmTerm#biologicalStatus: '500'
+        http://purl.org/germplasm/germplasmTerm#germplasmIdentifier: CGN00228
+        http://purl.org/germplasm/germplasmTerm#safetyDuplicationInstituteID: DEU146
+        http://purl.org/germplasm/germplasmTerm#mlsStatus: '1'
+        http://www.w3.org/2003/01/geo/wgs84_pos#lat: '53'
+        http://www.w3.org/2003/01/geo/wgs84_pos#long: '13'
+        http://purl.org/germplasm/germplasmTerm#donorInstituteID: NLD078
+        http://purl.org/germplasm/germplasmTerm#breedingIdentifier: Wieselburger 2-zeilige
+    basisOfRecord: LIVING_SPECIMEN
+    occurrenceStatus: PRESENT
+    taxonKey: 4932619
+    kingdomKey: 6
+    phylumKey: 7707728
+    classKey: 196
+    orderKey: 1369
+    familyKey: 3073
+    genusKey: 2706050
+    speciesKey: 2706056
+    acceptedTaxonKey: 4932619
+    scientificName: Hordeum vulgare subsp. vulgare
+    acceptedScientificName: Hordeum vulgare subsp. vulgare
+    kingdom: Plantae
+    phylum: Tracheophyta
+    order: Poales
+    family: Poaceae
+    genus: Hordeum
+    species: Hordeum vulgare
+    genericName: Hordeum
+    specificEpithet: vulgare
+    infraspecificEpithet: vulgare
+    taxonRank: SUBSPECIES
+    taxonomicStatus: ACCEPTED
+    decimalLatitude: 53.0
+    decimalLongitude: 13.0
+    continent: EUROPE
+    gadm:
+      level0:
+        gid: DEU
+        name: Germany
+      level1:
+        gid: DEU.4_1
+        name: Brandenburg
+      level2:
+        gid: DEU.4.12_1
+        name: Ostprignitz-Ruppin
+      level3:
+        gid: DEU.4.12.4_1
+        name: Lindow (Mark)
+    issues:
+    - COUNTRY_DERIVED_FROM_COORDINATES
+    - CONTINENT_DERIVED_FROM_COORDINATES
+    - TAXON_MATCH_SCIENTIFIC_NAME_ID_IGNORED
+    - INSTITUTION_MATCH_NONE
+    lastInterpreted: '2024-02-26T12:47:25.771+00:00'
+    license: http://creativecommons.org/publicdomain/zero/1.0/legalcode
+    isSequenced: false
+    identifiers:
+    - identifier: 10.18730/133S$
+    media:
+    - references: https://cgngenis.wur.nl/accessiondetails/CGN00228
+    facts: []
+    relations: []
+    isInCluster: false
+    datasetID: NLD
+    geodeticDatum: WGS84
+    class: Liliopsida
+    countryCode: DE
+    recordedByIDs: []
+    identifiedByIDs: []
+    gbifRegion: EUROPE
+    country: Germany
+    publishedByGbifRegion: EUROPE
+    identifier: 10.18730/133S$
+    catalogNumber: CGN00228
+    vernacularName: barley
+    scientificNameID: Hordeum vulgare subsp. vulgare L.
+    institutionCode: NLD037
+    gbifID: '4525980726'
+    occurrenceID: 10.18730/133S$
+  - key: 4525980777
+    datasetKey: 85796928-f762-11e1-a439-00145eb45e9a
+    publishingOrgKey: efc2ae40-9880-11da-89b4-b8a03c50a862
+    installationKey: 97dfec69-b198-43ba-a8fa-c5edbc04e324
+    hostingOrganizationKey: cace8d10-2646-11d8-a2da-b8a03c50a862
+    publishingCountry: NL
+    protocol: EML
+    lastCrawled: '2024-02-26T11:40:15.213+00:00'
+    lastParsed: '2024-02-26T12:47:25.781+00:00'
+    crawlId: 364
+    extensions:
+      http://purl.org/germplasm/germplasmTerm#GermplasmAccession:
+      - http://purl.org/germplasm/germplasmTerm#germplasmID: CGN00229
+        http://purl.org/germplasm/germplasmTerm#storageCondition: '-20'
+        http://purl.org/germplasm/germplasmTerm#biologicalStatus: '400'
+        http://purl.org/germplasm/germplasmTerm#germplasmIdentifier: CGN00229
+        http://purl.org/germplasm/germplasmTerm#safetyDuplicationInstituteID: DEU146
+        http://purl.org/germplasm/germplasmTerm#mlsStatus: '1'
+        http://www.w3.org/2003/01/geo/wgs84_pos#lat: '53'
+        http://www.w3.org/2003/01/geo/wgs84_pos#long: '13'
+        http://purl.org/germplasm/germplasmTerm#donorInstituteID: NLD078
+        http://purl.org/germplasm/germplasmTerm#breedingIdentifier: 2679/44
+    basisOfRecord: LIVING_SPECIMEN
+    occurrenceStatus: PRESENT
+    taxonKey: 4932619
+    kingdomKey: 6
+    phylumKey: 7707728
+    classKey: 196
+    orderKey: 1369
+    familyKey: 3073
+    genusKey: 2706050
+    speciesKey: 2706056
+    acceptedTaxonKey: 4932619
+    scientificName: Hordeum vulgare subsp. vulgare
+    acceptedScientificName: Hordeum vulgare subsp. vulgare
+    kingdom: Plantae
+    phylum: Tracheophyta
+    order: Poales
+    family: Poaceae
+    genus: Hordeum
+    species: Hordeum vulgare
+    genericName: Hordeum
+    specificEpithet: vulgare
+    infraspecificEpithet: vulgare
+    taxonRank: SUBSPECIES
+    taxonomicStatus: ACCEPTED
+    decimalLatitude: 53.0
+    decimalLongitude: 13.0
+    continent: EUROPE
+    gadm:
+      level0:
+        gid: DEU
+        name: Germany
+      level1:
+        gid: DEU.4_1
+        name: Brandenburg
+      level2:
+        gid: DEU.4.12_1
+        name: Ostprignitz-Ruppin
+      level3:
+        gid: DEU.4.12.4_1
+        name: Lindow (Mark)
+    issues:
+    - COUNTRY_DERIVED_FROM_COORDINATES
+    - CONTINENT_DERIVED_FROM_COORDINATES
+    - TAXON_MATCH_SCIENTIFIC_NAME_ID_IGNORED
+    - INSTITUTION_MATCH_NONE
+    lastInterpreted: '2024-02-26T12:47:25.781+00:00'
+    license: http://creativecommons.org/publicdomain/zero/1.0/legalcode
+    isSequenced: false
+    identifiers:
+    - identifier: 10.18730/133T=
+    media:
+    - references: https://cgngenis.wur.nl/accessiondetails/CGN00229
+    facts: []
+    relations: []
+    isInCluster: false
+    datasetID: NLD
+    geodeticDatum: WGS84
+    class: Liliopsida
+    countryCode: DE
+    recordedByIDs: []
+    identifiedByIDs: []
+    gbifRegion: EUROPE
+    country: Germany
+    publishedByGbifRegion: EUROPE
+    identifier: 10.18730/133T=
+    catalogNumber: CGN00229
+    vernacularName: barley
+    scientificNameID: Hordeum vulgare subsp. vulgare L.
+    institutionCode: NLD037
+    gbifID: '4525980777'
+    occurrenceID: 10.18730/133T=
+  - key: 4525980832
+    datasetKey: 85796928-f762-11e1-a439-00145eb45e9a
+    publishingOrgKey: efc2ae40-9880-11da-89b4-b8a03c50a862
+    installationKey: 97dfec69-b198-43ba-a8fa-c5edbc04e324
+    hostingOrganizationKey: cace8d10-2646-11d8-a2da-b8a03c50a862
+    publishingCountry: NL
+    protocol: EML
+    lastCrawled: '2024-02-26T11:40:15.213+00:00'
+    lastParsed: '2024-02-26T12:47:25.793+00:00'
+    crawlId: 364
+    extensions:
+      http://purl.org/germplasm/germplasmTerm#GermplasmAccession:
+      - http://purl.org/germplasm/germplasmTerm#germplasmID: CGN00239
+        http://purl.org/germplasm/germplasmTerm#purdyPedigree: Criewener/Pflugs
+        http://purl.org/germplasm/germplasmTerm#storageCondition: '-20'
+        http://purl.org/germplasm/germplasmTerm#biologicalStatus: '400'
+        http://purl.org/germplasm/germplasmTerm#germplasmIdentifier: CGN00239
+        http://purl.org/germplasm/germplasmTerm#safetyDuplicationInstituteID: DEU146
+        http://purl.org/germplasm/germplasmTerm#ancestralData: Criewener/Pflugs
+        http://purl.org/germplasm/germplasmTerm#mlsStatus: '1'
+        http://www.w3.org/2003/01/geo/wgs84_pos#lat: '53'
+        http://www.w3.org/2003/01/geo/wgs84_pos#long: '13'
+        http://purl.org/germplasm/germplasmTerm#donorInstituteID: NLD078
+    basisOfRecord: LIVING_SPECIMEN
+    occurrenceStatus: PRESENT
+    taxonKey: 4932619
+    kingdomKey: 6
+    phylumKey: 7707728
+    classKey: 196
+    orderKey: 1369
+    familyKey: 3073
+    genusKey: 2706050
+    speciesKey: 2706056
+    acceptedTaxonKey: 4932619
+    scientificName: Hordeum vulgare subsp. vulgare
+    acceptedScientificName: Hordeum vulgare subsp. vulgare
+    kingdom: Plantae
+    phylum: Tracheophyta
+    order: Poales
+    family: Poaceae
+    genus: Hordeum
+    species: Hordeum vulgare
+    genericName: Hordeum
+    specificEpithet: vulgare
+    infraspecificEpithet: vulgare
+    taxonRank: SUBSPECIES
+    taxonomicStatus: ACCEPTED
+    decimalLatitude: 53.0
+    decimalLongitude: 13.0
+    continent: EUROPE
+    gadm:
+      level0:
+        gid: DEU
+        name: Germany
+      level1:
+        gid: DEU.4_1
+        name: Brandenburg
+      level2:
+        gid: DEU.4.12_1
+        name: Ostprignitz-Ruppin
+      level3:
+        gid: DEU.4.12.4_1
+        name: Lindow (Mark)
+    issues:
+    - COUNTRY_DERIVED_FROM_COORDINATES
+    - CONTINENT_DERIVED_FROM_COORDINATES
+    - TAXON_MATCH_SCIENTIFIC_NAME_ID_IGNORED
+    - INSTITUTION_MATCH_NONE
+    lastInterpreted: '2024-02-26T12:47:25.793+00:00'
+    license: http://creativecommons.org/publicdomain/zero/1.0/legalcode
+    isSequenced: false
+    identifiers:
+    - identifier: 10.18730/13404
+    media:
+    - references: https://cgngenis.wur.nl/accessiondetails/CGN00239
+    facts: []
+    relations: []
+    isInCluster: false
+    datasetID: NLD
+    geodeticDatum: WGS84
+    class: Liliopsida
+    countryCode: DE
+    recordedByIDs: []
+    identifiedByIDs: []
+    gbifRegion: EUROPE
+    country: Germany
+    publishedByGbifRegion: EUROPE
+    identifier: 10.18730/13404
+    catalogNumber: CGN00239
+    vernacularName: barley
+    scientificNameID: Hordeum vulgare subsp. vulgare L.
+    institutionCode: NLD037
+    gbifID: '4525980832'
+    occurrenceID: 10.18730/13404
+  - key: 4525987547
+    datasetKey: 85796928-f762-11e1-a439-00145eb45e9a
+    publishingOrgKey: efc2ae40-9880-11da-89b4-b8a03c50a862
+    installationKey: 97dfec69-b198-43ba-a8fa-c5edbc04e324
+    hostingOrganizationKey: cace8d10-2646-11d8-a2da-b8a03c50a862
+    publishingCountry: NL
+    protocol: EML
+    lastCrawled: '2024-02-26T11:40:15.213+00:00'
+    lastParsed: '2024-02-26T12:47:27.082+00:00'
+    crawlId: 364
+    extensions:
+      http://purl.org/germplasm/germplasmTerm#GermplasmAccession:
+      - http://purl.org/germplasm/germplasmTerm#germplasmID: CGN00268
+        http://purl.org/germplasm/germplasmTerm#storageCondition: '-20'
+        http://purl.org/germplasm/germplasmTerm#germplasmIdentifier: CGN00268
+        http://purl.org/germplasm/germplasmTerm#safetyDuplicationInstituteID: DEU146
+        http://purl.org/germplasm/germplasmTerm#mlsStatus: '1'
+        http://www.w3.org/2003/01/geo/wgs84_pos#lat: '53'
+        http://www.w3.org/2003/01/geo/wgs84_pos#long: '13'
+        http://purl.org/germplasm/germplasmTerm#donorInstituteID: NLD078
+        http://purl.org/germplasm/germplasmTerm#breedingIdentifier: Lechtaler
+    basisOfRecord: LIVING_SPECIMEN
+    occurrenceStatus: PRESENT
+    taxonKey: 4932619
+    kingdomKey: 6
+    phylumKey: 7707728
+    classKey: 196
+    orderKey: 1369
+    familyKey: 3073
+    genusKey: 2706050
+    speciesKey: 2706056
+    acceptedTaxonKey: 4932619
+    scientificName: Hordeum vulgare subsp. vulgare
+    acceptedScientificName: Hordeum vulgare subsp. vulgare
+    kingdom: Plantae
+    phylum: Tracheophyta
+    order: Poales
+    family: Poaceae
+    genus: Hordeum
+    species: Hordeum vulgare
+    genericName: Hordeum
+    specificEpithet: vulgare
+    infraspecificEpithet: vulgare
+    taxonRank: SUBSPECIES
+    taxonomicStatus: ACCEPTED
+    decimalLatitude: 53.0
+    decimalLongitude: 13.0
+    continent: EUROPE
+    gadm:
+      level0:
+        gid: DEU
+        name: Germany
+      level1:
+        gid: DEU.4_1
+        name: Brandenburg
+      level2:
+        gid: DEU.4.12_1
+        name: Ostprignitz-Ruppin
+      level3:
+        gid: DEU.4.12.4_1
+        name: Lindow (Mark)
+    issues:
+    - COUNTRY_DERIVED_FROM_COORDINATES
+    - CONTINENT_DERIVED_FROM_COORDINATES
+    - TAXON_MATCH_SCIENTIFIC_NAME_ID_IGNORED
+    - INSTITUTION_MATCH_NONE
+    lastInterpreted: '2024-02-26T12:47:27.082+00:00'
+    license: http://creativecommons.org/publicdomain/zero/1.0/legalcode
+    isSequenced: false
+    identifiers:
+    - identifier: 10.18730/134QV
+    media:
+    - references: https://cgngenis.wur.nl/accessiondetails/CGN00268
+    facts: []
+    relations: []
+    isInCluster: false
+    datasetID: NLD
+    otherCatalogNumbers: USA027:CI 6488
+    geodeticDatum: WGS84
+    class: Liliopsida
+    countryCode: DE
+    recordedByIDs: []
+    identifiedByIDs: []
+    gbifRegion: EUROPE
+    country: Germany
+    publishedByGbifRegion: EUROPE
+    identifier: 10.18730/134QV
+    catalogNumber: CGN00268
+    vernacularName: barley
+    scientificNameID: Hordeum vulgare subsp. vulgare L.
+    institutionCode: NLD037
+    gbifID: '4525987547'
+    occurrenceID: 10.18730/134QV
+  - key: 4525987359
+    datasetKey: 85796928-f762-11e1-a439-00145eb45e9a
+    publishingOrgKey: efc2ae40-9880-11da-89b4-b8a03c50a862
+    installationKey: 97dfec69-b198-43ba-a8fa-c5edbc04e324
+    hostingOrganizationKey: cace8d10-2646-11d8-a2da-b8a03c50a862
+    publishingCountry: NL
+    protocol: EML
+    lastCrawled: '2024-02-26T11:40:15.213+00:00'
+    lastParsed: '2024-02-26T12:47:27.041+00:00'
+    crawlId: 364
+    extensions:
+      http://purl.org/germplasm/germplasmTerm#GermplasmAccession:
+      - http://purl.org/germplasm/germplasmTerm#germplasmID: CGN00269
+        http://purl.org/germplasm/germplasmTerm#purdyPedigree: Haisa/Imperial/H.spontaneum
+        http://purl.org/germplasm/germplasmTerm#storageCondition: '-20'
+        http://purl.org/germplasm/germplasmTerm#germplasmIdentifier: CGN00269
+        http://purl.org/germplasm/germplasmTerm#safetyDuplicationInstituteID: DEU146
+        http://purl.org/germplasm/germplasmTerm#ancestralData: Haisa/Imperial/H.spontaneum
+        http://purl.org/germplasm/germplasmTerm#mlsStatus: '1'
+        http://www.w3.org/2003/01/geo/wgs84_pos#lat: '53'
+        http://www.w3.org/2003/01/geo/wgs84_pos#long: '13'
+        http://purl.org/germplasm/germplasmTerm#donorInstituteID: NLD078
+        http://purl.org/germplasm/germplasmTerm#breedingIdentifier: Hispont
+    basisOfRecord: LIVING_SPECIMEN
+    occurrenceStatus: PRESENT
+    taxonKey: 4932619
+    kingdomKey: 6
+    phylumKey: 7707728
+    classKey: 196
+    orderKey: 1369
+    familyKey: 3073
+    genusKey: 2706050
+    speciesKey: 2706056
+    acceptedTaxonKey: 4932619
+    scientificName: Hordeum vulgare subsp. vulgare
+    acceptedScientificName: Hordeum vulgare subsp. vulgare
+    kingdom: Plantae
+    phylum: Tracheophyta
+    order: Poales
+    family: Poaceae
+    genus: Hordeum
+    species: Hordeum vulgare
+    genericName: Hordeum
+    specificEpithet: vulgare
+    infraspecificEpithet: vulgare
+    taxonRank: SUBSPECIES
+    taxonomicStatus: ACCEPTED
+    decimalLatitude: 53.0
+    decimalLongitude: 13.0
+    continent: EUROPE
+    gadm:
+      level0:
+        gid: DEU
+        name: Germany
+      level1:
+        gid: DEU.4_1
+        name: Brandenburg
+      level2:
+        gid: DEU.4.12_1
+        name: Ostprignitz-Ruppin
+      level3:
+        gid: DEU.4.12.4_1
+        name: Lindow (Mark)
+    issues:
+    - COUNTRY_DERIVED_FROM_COORDINATES
+    - CONTINENT_DERIVED_FROM_COORDINATES
+    - TAXON_MATCH_SCIENTIFIC_NAME_ID_IGNORED
+    - INSTITUTION_MATCH_NONE
+    lastInterpreted: '2024-02-26T12:47:27.041+00:00'
+    license: http://creativecommons.org/publicdomain/zero/1.0/legalcode
+    isSequenced: false
+    identifiers:
+    - identifier: 10.18730/134RW
+    media:
+    - references: https://cgngenis.wur.nl/accessiondetails/CGN00269
+    facts: []
+    relations: []
+    isInCluster: false
+    datasetID: NLD
+    otherCatalogNumbers: USA007:PI 180687|USA027:CI 8828
+    geodeticDatum: WGS84
+    class: Liliopsida
+    countryCode: DE
+    recordedByIDs: []
+    identifiedByIDs: []
+    gbifRegion: EUROPE
+    country: Germany
+    publishedByGbifRegion: EUROPE
+    identifier: 10.18730/134RW
+    catalogNumber: CGN00269
+    vernacularName: barley
+    scientificNameID: Hordeum vulgare subsp. vulgare L.
+    institutionCode: NLD037
+    gbifID: '4525987359'
+    occurrenceID: 10.18730/134RW
+  - key: 4525987543
+    datasetKey: 85796928-f762-11e1-a439-00145eb45e9a
+    publishingOrgKey: efc2ae40-9880-11da-89b4-b8a03c50a862
+    installationKey: 97dfec69-b198-43ba-a8fa-c5edbc04e324
+    hostingOrganizationKey: cace8d10-2646-11d8-a2da-b8a03c50a862
+    publishingCountry: NL
+    protocol: EML
+    lastCrawled: '2024-02-26T11:40:15.213+00:00'
+    lastParsed: '2024-02-26T12:47:27.100+00:00'
+    crawlId: 364
+    extensions:
+      http://purl.org/germplasm/germplasmTerm#GermplasmAccession:
+      - http://purl.org/germplasm/germplasmTerm#germplasmID: CGN00281
+        http://purl.org/germplasm/germplasmTerm#storageCondition: '-20'
+        http://purl.org/germplasm/germplasmTerm#germplasmIdentifier: CGN00281
+        http://purl.org/germplasm/germplasmTerm#safetyDuplicationInstituteID: DEU146
+        http://purl.org/germplasm/germplasmTerm#mlsStatus: '1'
+        http://www.w3.org/2003/01/geo/wgs84_pos#lat: '53'
+        http://www.w3.org/2003/01/geo/wgs84_pos#long: '13'
+        http://purl.org/germplasm/germplasmTerm#donorInstituteID: NLD078
+        http://purl.org/germplasm/germplasmTerm#breedingIdentifier: Hor.793
+    basisOfRecord: LIVING_SPECIMEN
+    occurrenceStatus: PRESENT
+    taxonKey: 4932619
+    kingdomKey: 6
+    phylumKey: 7707728
+    classKey: 196
+    orderKey: 1369
+    familyKey: 3073
+    genusKey: 2706050
+    speciesKey: 2706056
+    acceptedTaxonKey: 4932619
+    scientificName: Hordeum vulgare subsp. vulgare
+    acceptedScientificName: Hordeum vulgare subsp. vulgare
+    kingdom: Plantae
+    phylum: Tracheophyta
+    order: Poales
+    family: Poaceae
+    genus: Hordeum
+    species: Hordeum vulgare
+    genericName: Hordeum
+    specificEpithet: vulgare
+    infraspecificEpithet: vulgare
+    taxonRank: SUBSPECIES
+    taxonomicStatus: ACCEPTED
+    decimalLatitude: 53.0
+    decimalLongitude: 13.0
+    continent: EUROPE
+    gadm:
+      level0:
+        gid: DEU
+        name: Germany
+      level1:
+        gid: DEU.4_1
+        name: Brandenburg
+      level2:
+        gid: DEU.4.12_1
+        name: Ostprignitz-Ruppin
+      level3:
+        gid: DEU.4.12.4_1
+        name: Lindow (Mark)
+    issues:
+    - COUNTRY_DERIVED_FROM_COORDINATES
+    - CONTINENT_DERIVED_FROM_COORDINATES
+    - TAXON_MATCH_SCIENTIFIC_NAME_ID_IGNORED
+    - INSTITUTION_MATCH_NONE
+    lastInterpreted: '2024-02-26T12:47:27.100+00:00'
+    license: http://creativecommons.org/publicdomain/zero/1.0/legalcode
+    isSequenced: false
+    identifiers:
+    - identifier: 10.18730/13532
+    media:
+    - references: https://cgngenis.wur.nl/accessiondetails/CGN00281
+    facts: []
+    relations: []
+    isInCluster: false
+    datasetID: NLD
+    geodeticDatum: WGS84
+    class: Liliopsida
+    countryCode: DE
+    recordedByIDs: []
+    identifiedByIDs: []
+    gbifRegion: EUROPE
+    country: Germany
+    publishedByGbifRegion: EUROPE
+    identifier: 10.18730/13532
+    catalogNumber: CGN00281
+    vernacularName: barley
+    scientificNameID: Hordeum vulgare subsp. vulgare L.
+    institutionCode: NLD037
+    gbifID: '4525987543'
+    occurrenceID: 10.18730/13532
+  - key: 4525987355
+    datasetKey: 85796928-f762-11e1-a439-00145eb45e9a
+    publishingOrgKey: efc2ae40-9880-11da-89b4-b8a03c50a862
+    installationKey: 97dfec69-b198-43ba-a8fa-c5edbc04e324
+    hostingOrganizationKey: cace8d10-2646-11d8-a2da-b8a03c50a862
+    publishingCountry: NL
+    protocol: EML
+    lastCrawled: '2024-02-26T11:40:15.213+00:00'
+    lastParsed: '2024-02-26T12:47:27.039+00:00'
+    crawlId: 364
+    extensions:
+      http://purl.org/germplasm/germplasmTerm#GermplasmAccession:
+      - http://purl.org/germplasm/germplasmTerm#germplasmID: CGN00282
+        http://purl.org/germplasm/germplasmTerm#storageCondition: '-20'
+        http://purl.org/germplasm/germplasmTerm#germplasmIdentifier: CGN00282
+        http://purl.org/germplasm/germplasmTerm#safetyDuplicationInstituteID: DEU146
+        http://purl.org/germplasm/germplasmTerm#mlsStatus: '1'
+        http://www.w3.org/2003/01/geo/wgs84_pos#lat: '53'
+        http://www.w3.org/2003/01/geo/wgs84_pos#long: '13'
+        http://purl.org/germplasm/germplasmTerm#donorInstituteID: NLD078
+        http://purl.org/germplasm/germplasmTerm#breedingIdentifier: Hor.1457
+    basisOfRecord: LIVING_SPECIMEN
+    occurrenceStatus: PRESENT
+    taxonKey: 4932619
+    kingdomKey: 6
+    phylumKey: 7707728
+    classKey: 196
+    orderKey: 1369
+    familyKey: 3073
+    genusKey: 2706050
+    speciesKey: 2706056
+    acceptedTaxonKey: 4932619
+    scientificName: Hordeum vulgare subsp. vulgare
+    acceptedScientificName: Hordeum vulgare subsp. vulgare
+    kingdom: Plantae
+    phylum: Tracheophyta
+    order: Poales
+    family: Poaceae
+    genus: Hordeum
+    species: Hordeum vulgare
+    genericName: Hordeum
+    specificEpithet: vulgare
+    infraspecificEpithet: vulgare
+    taxonRank: SUBSPECIES
+    taxonomicStatus: ACCEPTED
+    decimalLatitude: 53.0
+    decimalLongitude: 13.0
+    continent: EUROPE
+    gadm:
+      level0:
+        gid: DEU
+        name: Germany
+      level1:
+        gid: DEU.4_1
+        name: Brandenburg
+      level2:
+        gid: DEU.4.12_1
+        name: Ostprignitz-Ruppin
+      level3:
+        gid: DEU.4.12.4_1
+        name: Lindow (Mark)
+    issues:
+    - COUNTRY_DERIVED_FROM_COORDINATES
+    - CONTINENT_DERIVED_FROM_COORDINATES
+    - TAXON_MATCH_SCIENTIFIC_NAME_ID_IGNORED
+    - INSTITUTION_MATCH_NONE
+    lastInterpreted: '2024-02-26T12:47:27.039+00:00'
+    license: http://creativecommons.org/publicdomain/zero/1.0/legalcode
+    isSequenced: false
+    identifiers:
+    - identifier: 10.18730/13543
+    media:
+    - references: https://cgngenis.wur.nl/accessiondetails/CGN00282
+    facts: []
+    relations: []
+    isInCluster: false
+    datasetID: NLD
+    geodeticDatum: WGS84
+    class: Liliopsida
+    countryCode: DE
+    recordedByIDs: []
+    identifiedByIDs: []
+    gbifRegion: EUROPE
+    country: Germany
+    publishedByGbifRegion: EUROPE
+    identifier: 10.18730/13543
+    catalogNumber: CGN00282
+    vernacularName: barley
+    scientificNameID: Hordeum vulgare subsp. vulgare L.
+    institutionCode: NLD037
+    gbifID: '4525987355'
+    occurrenceID: 10.18730/13543
+  - key: 4525987654
+    datasetKey: 85796928-f762-11e1-a439-00145eb45e9a
+    publishingOrgKey: efc2ae40-9880-11da-89b4-b8a03c50a862
+    installationKey: 97dfec69-b198-43ba-a8fa-c5edbc04e324
+    hostingOrganizationKey: cace8d10-2646-11d8-a2da-b8a03c50a862
+    publishingCountry: NL
+    protocol: EML
+    lastCrawled: '2024-02-26T11:40:15.213+00:00'
+    lastParsed: '2024-02-26T12:47:27.102+00:00'
+    crawlId: 364
+    extensions:
+      http://purl.org/germplasm/germplasmTerm#GermplasmAccession:
+      - http://purl.org/germplasm/germplasmTerm#germplasmID: CGN00289
+        http://purl.org/germplasm/germplasmTerm#storageCondition: '-20'
+        http://purl.org/germplasm/germplasmTerm#biologicalStatus: '400'
+        http://purl.org/germplasm/germplasmTerm#germplasmIdentifier: CGN00289
+        http://purl.org/germplasm/germplasmTerm#safetyDuplicationInstituteID: DEU146
+        http://purl.org/germplasm/germplasmTerm#mlsStatus: '1'
+        http://www.w3.org/2003/01/geo/wgs84_pos#lat: '53'
+        http://www.w3.org/2003/01/geo/wgs84_pos#long: '13'
+        http://purl.org/germplasm/germplasmTerm#donorInstituteID: NLD078
+        http://purl.org/germplasm/germplasmTerm#breedingIdentifier: Linie 4831
+    basisOfRecord: LIVING_SPECIMEN
+    occurrenceStatus: PRESENT
+    taxonKey: 4932619
+    kingdomKey: 6
+    phylumKey: 7707728
+    classKey: 196
+    orderKey: 1369
+    familyKey: 3073
+    genusKey: 2706050
+    speciesKey: 2706056
+    acceptedTaxonKey: 4932619
+    scientificName: Hordeum vulgare subsp. vulgare
+    acceptedScientificName: Hordeum vulgare subsp. vulgare
+    kingdom: Plantae
+    phylum: Tracheophyta
+    order: Poales
+    family: Poaceae
+    genus: Hordeum
+    species: Hordeum vulgare
+    genericName: Hordeum
+    specificEpithet: vulgare
+    infraspecificEpithet: vulgare
+    taxonRank: SUBSPECIES
+    taxonomicStatus: ACCEPTED
+    decimalLatitude: 53.0
+    decimalLongitude: 13.0
+    continent: EUROPE
+    gadm:
+      level0:
+        gid: DEU
+        name: Germany
+      level1:
+        gid: DEU.4_1
+        name: Brandenburg
+      level2:
+        gid: DEU.4.12_1
+        name: Ostprignitz-Ruppin
+      level3:
+        gid: DEU.4.12.4_1
+        name: Lindow (Mark)
+    issues:
+    - COUNTRY_DERIVED_FROM_COORDINATES
+    - CONTINENT_DERIVED_FROM_COORDINATES
+    - TAXON_MATCH_SCIENTIFIC_NAME_ID_IGNORED
+    - INSTITUTION_MATCH_NONE
+    lastInterpreted: '2024-02-26T12:47:27.102+00:00'
+    license: http://creativecommons.org/publicdomain/zero/1.0/legalcode
+    isSequenced: false
+    identifiers:
+    - identifier: 10.18730/13587
+    media:
+    - references: https://cgngenis.wur.nl/accessiondetails/CGN00289
+    facts: []
+    relations: []
+    isInCluster: false
+    datasetID: NLD
+    geodeticDatum: WGS84
+    class: Liliopsida
+    countryCode: DE
+    recordedByIDs: []
+    identifiedByIDs: []
+    gbifRegion: EUROPE
+    country: Germany
+    publishedByGbifRegion: EUROPE
+    identifier: 10.18730/13587
+    catalogNumber: CGN00289
+    vernacularName: barley
+    scientificNameID: Hordeum vulgare subsp. vulgare L.
+    institutionCode: NLD037
+    gbifID: '4525987654'
+    occurrenceID: 10.18730/13587
+  - key: 4525987682
+    datasetKey: 85796928-f762-11e1-a439-00145eb45e9a
+    publishingOrgKey: efc2ae40-9880-11da-89b4-b8a03c50a862
+    installationKey: 97dfec69-b198-43ba-a8fa-c5edbc04e324
+    hostingOrganizationKey: cace8d10-2646-11d8-a2da-b8a03c50a862
+    publishingCountry: NL
+    protocol: EML
+    lastCrawled: '2024-02-26T11:40:15.213+00:00'
+    lastParsed: '2024-02-26T12:47:27.106+00:00'
+    crawlId: 364
+    extensions:
+      http://purl.org/germplasm/germplasmTerm#GermplasmAccession:
+      - http://purl.org/germplasm/germplasmTerm#germplasmID: CGN00290
+        http://purl.org/germplasm/germplasmTerm#storageCondition: '-20'
+        http://purl.org/germplasm/germplasmTerm#biologicalStatus: '500'
+        http://purl.org/germplasm/germplasmTerm#germplasmIdentifier: CGN00290
+        http://purl.org/germplasm/germplasmTerm#safetyDuplicationInstituteID: DEU146
+        http://purl.org/germplasm/germplasmTerm#mlsStatus: '1'
+        http://www.w3.org/2003/01/geo/wgs84_pos#lat: '53'
+        http://www.w3.org/2003/01/geo/wgs84_pos#long: '13'
+        http://purl.org/germplasm/germplasmTerm#donorInstituteID: NLD078
+        http://purl.org/germplasm/germplasmTerm#breedingIdentifier: Berg
+    basisOfRecord: LIVING_SPECIMEN
+    occurrenceStatus: PRESENT
+    taxonKey: 4932619
+    kingdomKey: 6
+    phylumKey: 7707728
+    classKey: 196
+    orderKey: 1369
+    familyKey: 3073
+    genusKey: 2706050
+    speciesKey: 2706056
+    acceptedTaxonKey: 4932619
+    scientificName: Hordeum vulgare subsp. vulgare
+    acceptedScientificName: Hordeum vulgare subsp. vulgare
+    kingdom: Plantae
+    phylum: Tracheophyta
+    order: Poales
+    family: Poaceae
+    genus: Hordeum
+    species: Hordeum vulgare
+    genericName: Hordeum
+    specificEpithet: vulgare
+    infraspecificEpithet: vulgare
+    taxonRank: SUBSPECIES
+    taxonomicStatus: ACCEPTED
+    decimalLatitude: 53.0
+    decimalLongitude: 13.0
+    continent: EUROPE
+    gadm:
+      level0:
+        gid: DEU
+        name: Germany
+      level1:
+        gid: DEU.4_1
+        name: Brandenburg
+      level2:
+        gid: DEU.4.12_1
+        name: Ostprignitz-Ruppin
+      level3:
+        gid: DEU.4.12.4_1
+        name: Lindow (Mark)
+    issues:
+    - COUNTRY_DERIVED_FROM_COORDINATES
+    - CONTINENT_DERIVED_FROM_COORDINATES
+    - TAXON_MATCH_SCIENTIFIC_NAME_ID_IGNORED
+    - INSTITUTION_MATCH_NONE
+    lastInterpreted: '2024-02-26T12:47:27.106+00:00'
+    license: http://creativecommons.org/publicdomain/zero/1.0/legalcode
+    isSequenced: false
+    identifiers:
+    - identifier: 10.18730/13598
+    media:
+    - references: https://cgngenis.wur.nl/accessiondetails/CGN00290
+    facts: []
+    relations: []
+    isInCluster: false
+    datasetID: NLD
+    geodeticDatum: WGS84
+    class: Liliopsida
+    countryCode: DE
+    recordedByIDs: []
+    identifiedByIDs: []
+    gbifRegion: EUROPE
+    country: Germany
+    publishedByGbifRegion: EUROPE
+    identifier: 10.18730/13598
+    catalogNumber: CGN00290
+    vernacularName: barley
+    scientificNameID: Hordeum vulgare subsp. vulgare L.
+    institutionCode: NLD037
+    gbifID: '4525987682'
+    occurrenceID: 10.18730/13598
+  - key: 4525988739
+    datasetKey: 85796928-f762-11e1-a439-00145eb45e9a
+    publishingOrgKey: efc2ae40-9880-11da-89b4-b8a03c50a862
+    installationKey: 97dfec69-b198-43ba-a8fa-c5edbc04e324
+    hostingOrganizationKey: cace8d10-2646-11d8-a2da-b8a03c50a862
+    publishingCountry: NL
+    protocol: EML
+    lastCrawled: '2024-02-26T11:40:15.213+00:00'
+    lastParsed: '2024-02-26T12:47:27.288+00:00'
+    crawlId: 364
+    extensions:
+      http://purl.org/germplasm/germplasmTerm#GermplasmAccession:
+      - http://purl.org/germplasm/germplasmTerm#germplasmID: CGN00343
+        http://purl.org/germplasm/germplasmTerm#purdyPedigree: Triple Awn Lemma/Rigel
+        http://purl.org/germplasm/germplasmTerm#storageCondition: '-20'
+        http://purl.org/germplasm/germplasmTerm#biologicalStatus: '400'
+        http://purl.org/germplasm/germplasmTerm#germplasmIdentifier: CGN00343
+        http://purl.org/germplasm/germplasmTerm#safetyDuplicationInstituteID: DEU146
+        http://purl.org/germplasm/germplasmTerm#ancestralData: Triple Awn Lemma/Rigel
+        http://purl.org/germplasm/germplasmTerm#mlsStatus: '1'
+        http://www.w3.org/2003/01/geo/wgs84_pos#lat: '53'
+        http://www.w3.org/2003/01/geo/wgs84_pos#long: '13'
+        http://purl.org/germplasm/germplasmTerm#donorInstituteID: NLD078
+    basisOfRecord: LIVING_SPECIMEN
+    occurrenceStatus: PRESENT
+    taxonKey: 4932619
+    kingdomKey: 6
+    phylumKey: 7707728
+    classKey: 196
+    orderKey: 1369
+    familyKey: 3073
+    genusKey: 2706050
+    speciesKey: 2706056
+    acceptedTaxonKey: 4932619
+    scientificName: Hordeum vulgare subsp. vulgare
+    acceptedScientificName: Hordeum vulgare subsp. vulgare
+    kingdom: Plantae
+    phylum: Tracheophyta
+    order: Poales
+    family: Poaceae
+    genus: Hordeum
+    species: Hordeum vulgare
+    genericName: Hordeum
+    specificEpithet: vulgare
+    infraspecificEpithet: vulgare
+    taxonRank: SUBSPECIES
+    taxonomicStatus: ACCEPTED
+    decimalLatitude: 53.0
+    decimalLongitude: 13.0
+    continent: EUROPE
+    gadm:
+      level0:
+        gid: DEU
+        name: Germany
+      level1:
+        gid: DEU.4_1
+        name: Brandenburg
+      level2:
+        gid: DEU.4.12_1
+        name: Ostprignitz-Ruppin
+      level3:
+        gid: DEU.4.12.4_1
+        name: Lindow (Mark)
+    issues:
+    - COUNTRY_DERIVED_FROM_COORDINATES
+    - CONTINENT_DERIVED_FROM_COORDINATES
+    - TAXON_MATCH_SCIENTIFIC_NAME_ID_IGNORED
+    - INSTITUTION_MATCH_NONE
+    lastInterpreted: '2024-02-26T12:47:27.288+00:00'
+    license: http://creativecommons.org/publicdomain/zero/1.0/legalcode
+    isSequenced: false
+    identifiers:
+    - identifier: 10.18730/136WP
+    media:
+    - references: https://cgngenis.wur.nl/accessiondetails/CGN00343
+    facts: []
+    relations: []
+    isInCluster: false
+    datasetID: NLD
+    geodeticDatum: WGS84
+    class: Liliopsida
+    countryCode: DE
+    recordedByIDs: []
+    identifiedByIDs: []
+    gbifRegion: EUROPE
+    country: Germany
+    publishedByGbifRegion: EUROPE
+    identifier: 10.18730/136WP
+    catalogNumber: CGN00343
+    vernacularName: barley
+    scientificNameID: Hordeum vulgare subsp. vulgare L.
+    institutionCode: NLD037
+    gbifID: '4525988739'
+    occurrenceID: 10.18730/136WP
+  - key: 4525988762
+    datasetKey: 85796928-f762-11e1-a439-00145eb45e9a
+    publishingOrgKey: efc2ae40-9880-11da-89b4-b8a03c50a862
+    installationKey: 97dfec69-b198-43ba-a8fa-c5edbc04e324
+    hostingOrganizationKey: cace8d10-2646-11d8-a2da-b8a03c50a862
+    publishingCountry: NL
+    protocol: EML
+    lastCrawled: '2024-02-26T11:40:15.213+00:00'
+    lastParsed: '2024-02-26T12:47:27.291+00:00'
+    crawlId: 364
+    extensions:
+      http://purl.org/germplasm/germplasmTerm#GermplasmAccession:
+      - http://purl.org/germplasm/germplasmTerm#germplasmID: CGN00344
+        http://purl.org/germplasm/germplasmTerm#purdyPedigree: Forrajera/Rika
+        http://purl.org/germplasm/germplasmTerm#storageCondition: '-20'
+        http://purl.org/germplasm/germplasmTerm#biologicalStatus: '400'
+        http://purl.org/germplasm/germplasmTerm#germplasmIdentifier: CGN00344
+        http://purl.org/germplasm/germplasmTerm#safetyDuplicationInstituteID: DEU146
+        http://purl.org/germplasm/germplasmTerm#ancestralData: Forrajera/Rika
+        http://purl.org/germplasm/germplasmTerm#mlsStatus: '1'
+        http://www.w3.org/2003/01/geo/wgs84_pos#lat: '53'
+        http://www.w3.org/2003/01/geo/wgs84_pos#long: '13'
+        http://purl.org/germplasm/germplasmTerm#donorInstituteID: NLD078
+    basisOfRecord: LIVING_SPECIMEN
+    occurrenceStatus: PRESENT
+    taxonKey: 4932619
+    kingdomKey: 6
+    phylumKey: 7707728
+    classKey: 196
+    orderKey: 1369
+    familyKey: 3073
+    genusKey: 2706050
+    speciesKey: 2706056
+    acceptedTaxonKey: 4932619
+    scientificName: Hordeum vulgare subsp. vulgare
+    acceptedScientificName: Hordeum vulgare subsp. vulgare
+    kingdom: Plantae
+    phylum: Tracheophyta
+    order: Poales
+    family: Poaceae
+    genus: Hordeum
+    species: Hordeum vulgare
+    genericName: Hordeum
+    specificEpithet: vulgare
+    infraspecificEpithet: vulgare
+    taxonRank: SUBSPECIES
+    taxonomicStatus: ACCEPTED
+    decimalLatitude: 53.0
+    decimalLongitude: 13.0
+    continent: EUROPE
+    gadm:
+      level0:
+        gid: DEU
+        name: Germany
+      level1:
+        gid: DEU.4_1
+        name: Brandenburg
+      level2:
+        gid: DEU.4.12_1
+        name: Ostprignitz-Ruppin
+      level3:
+        gid: DEU.4.12.4_1
+        name: Lindow (Mark)
+    issues:
+    - COUNTRY_DERIVED_FROM_COORDINATES
+    - CONTINENT_DERIVED_FROM_COORDINATES
+    - TAXON_MATCH_SCIENTIFIC_NAME_ID_IGNORED
+    - INSTITUTION_MATCH_NONE
+    lastInterpreted: '2024-02-26T12:47:27.291+00:00'
+    license: http://creativecommons.org/publicdomain/zero/1.0/legalcode
+    isSequenced: false
+    identifiers:
+    - identifier: 10.18730/136XQ
+    media:
+    - references: https://cgngenis.wur.nl/accessiondetails/CGN00344
+    facts: []
+    relations: []
+    isInCluster: false
+    datasetID: NLD
+    geodeticDatum: WGS84
+    class: Liliopsida
+    countryCode: DE
+    recordedByIDs: []
+    identifiedByIDs: []
+    gbifRegion: EUROPE
+    country: Germany
+    publishedByGbifRegion: EUROPE
+    identifier: 10.18730/136XQ
+    catalogNumber: CGN00344
+    vernacularName: barley
+    scientificNameID: Hordeum vulgare subsp. vulgare L.
+    institutionCode: NLD037
+    gbifID: '4525988762'
+    occurrenceID: 10.18730/136XQ
+  - key: 4525988779
+    datasetKey: 85796928-f762-11e1-a439-00145eb45e9a
+    publishingOrgKey: efc2ae40-9880-11da-89b4-b8a03c50a862
+    installationKey: 97dfec69-b198-43ba-a8fa-c5edbc04e324
+    hostingOrganizationKey: cace8d10-2646-11d8-a2da-b8a03c50a862
+    publishingCountry: NL
+    protocol: EML
+    lastCrawled: '2024-02-26T11:40:15.213+00:00'
+    lastParsed: '2024-02-26T12:47:27.295+00:00'
+    crawlId: 364
+    extensions:
+      http://purl.org/germplasm/germplasmTerm#GermplasmAccession:
+      - http://purl.org/germplasm/germplasmTerm#germplasmID: CGN00345
+        http://purl.org/germplasm/germplasmTerm#purdyPedigree: La Estanzuela 75A/Rika
+        http://purl.org/germplasm/germplasmTerm#storageCondition: '-20'
+        http://purl.org/germplasm/germplasmTerm#biologicalStatus: '400'
+        http://purl.org/germplasm/germplasmTerm#germplasmIdentifier: CGN00345
+        http://purl.org/germplasm/germplasmTerm#safetyDuplicationInstituteID: DEU146
+        http://purl.org/germplasm/germplasmTerm#ancestralData: La Estanzuela 75A/Rika
+        http://purl.org/germplasm/germplasmTerm#mlsStatus: '1'
+        http://www.w3.org/2003/01/geo/wgs84_pos#lat: '53'
+        http://www.w3.org/2003/01/geo/wgs84_pos#long: '13'
+        http://purl.org/germplasm/germplasmTerm#donorInstituteID: NLD078
+    basisOfRecord: LIVING_SPECIMEN
+    occurrenceStatus: PRESENT
+    taxonKey: 4932619
+    kingdomKey: 6
+    phylumKey: 7707728
+    classKey: 196
+    orderKey: 1369
+    familyKey: 3073
+    genusKey: 2706050
+    speciesKey: 2706056
+    acceptedTaxonKey: 4932619
+    scientificName: Hordeum vulgare subsp. vulgare
+    acceptedScientificName: Hordeum vulgare subsp. vulgare
+    kingdom: Plantae
+    phylum: Tracheophyta
+    order: Poales
+    family: Poaceae
+    genus: Hordeum
+    species: Hordeum vulgare
+    genericName: Hordeum
+    specificEpithet: vulgare
+    infraspecificEpithet: vulgare
+    taxonRank: SUBSPECIES
+    taxonomicStatus: ACCEPTED
+    decimalLatitude: 53.0
+    decimalLongitude: 13.0
+    continent: EUROPE
+    gadm:
+      level0:
+        gid: DEU
+        name: Germany
+      level1:
+        gid: DEU.4_1
+        name: Brandenburg
+      level2:
+        gid: DEU.4.12_1
+        name: Ostprignitz-Ruppin
+      level3:
+        gid: DEU.4.12.4_1
+        name: Lindow (Mark)
+    issues:
+    - COUNTRY_DERIVED_FROM_COORDINATES
+    - CONTINENT_DERIVED_FROM_COORDINATES
+    - TAXON_MATCH_SCIENTIFIC_NAME_ID_IGNORED
+    - INSTITUTION_MATCH_NONE
+    lastInterpreted: '2024-02-26T12:47:27.295+00:00'
+    license: http://creativecommons.org/publicdomain/zero/1.0/legalcode
+    isSequenced: false
+    identifiers:
+    - identifier: 10.18730/136YR
+    media:
+    - references: https://cgngenis.wur.nl/accessiondetails/CGN00345
+    facts: []
+    relations: []
+    isInCluster: false
+    datasetID: NLD
+    geodeticDatum: WGS84
+    class: Liliopsida
+    countryCode: DE
+    recordedByIDs: []
+    identifiedByIDs: []
+    gbifRegion: EUROPE
+    country: Germany
+    publishedByGbifRegion: EUROPE
+    identifier: 10.18730/136YR
+    catalogNumber: CGN00345
+    vernacularName: barley
+    scientificNameID: Hordeum vulgare subsp. vulgare L.
+    institutionCode: NLD037
+    gbifID: '4525988779'
+    occurrenceID: 10.18730/136YR
+  - key: 4525988610
+    datasetKey: 85796928-f762-11e1-a439-00145eb45e9a
+    publishingOrgKey: efc2ae40-9880-11da-89b4-b8a03c50a862
+    installationKey: 97dfec69-b198-43ba-a8fa-c5edbc04e324
+    hostingOrganizationKey: cace8d10-2646-11d8-a2da-b8a03c50a862
+    publishingCountry: NL
+    protocol: EML
+    lastCrawled: '2024-02-26T11:40:15.213+00:00'
+    lastParsed: '2024-02-26T12:47:27.271+00:00'
+    crawlId: 364
+    extensions:
+      http://purl.org/germplasm/germplasmTerm#GermplasmAccession:
+      - http://purl.org/germplasm/germplasmTerm#germplasmID: CGN00347
+        http://purl.org/germplasm/germplasmTerm#purdyPedigree: Freja/Jerusalem
+        http://purl.org/germplasm/germplasmTerm#storageCondition: '-20'
+        http://purl.org/germplasm/germplasmTerm#biologicalStatus: '400'
+        http://purl.org/germplasm/germplasmTerm#germplasmIdentifier: CGN00347
+        http://purl.org/germplasm/germplasmTerm#safetyDuplicationInstituteID: DEU146
+        http://purl.org/germplasm/germplasmTerm#ancestralData: Freja/Jerusalem
+        http://purl.org/germplasm/germplasmTerm#mlsStatus: '1'
+        http://www.w3.org/2003/01/geo/wgs84_pos#lat: '53'
+        http://www.w3.org/2003/01/geo/wgs84_pos#long: '13'
+        http://purl.org/germplasm/germplasmTerm#donorInstituteID: NLD078
+    basisOfRecord: LIVING_SPECIMEN
+    occurrenceStatus: PRESENT
+    taxonKey: 4932619
+    kingdomKey: 6
+    phylumKey: 7707728
+    classKey: 196
+    orderKey: 1369
+    familyKey: 3073
+    genusKey: 2706050
+    speciesKey: 2706056
+    acceptedTaxonKey: 4932619
+    scientificName: Hordeum vulgare subsp. vulgare
+    acceptedScientificName: Hordeum vulgare subsp. vulgare
+    kingdom: Plantae
+    phylum: Tracheophyta
+    order: Poales
+    family: Poaceae
+    genus: Hordeum
+    species: Hordeum vulgare
+    genericName: Hordeum
+    specificEpithet: vulgare
+    infraspecificEpithet: vulgare
+    taxonRank: SUBSPECIES
+    taxonomicStatus: ACCEPTED
+    decimalLatitude: 53.0
+    decimalLongitude: 13.0
+    continent: EUROPE
+    gadm:
+      level0:
+        gid: DEU
+        name: Germany
+      level1:
+        gid: DEU.4_1
+        name: Brandenburg
+      level2:
+        gid: DEU.4.12_1
+        name: Ostprignitz-Ruppin
+      level3:
+        gid: DEU.4.12.4_1
+        name: Lindow (Mark)
+    issues:
+    - COUNTRY_DERIVED_FROM_COORDINATES
+    - CONTINENT_DERIVED_FROM_COORDINATES
+    - TAXON_MATCH_SCIENTIFIC_NAME_ID_IGNORED
+    - INSTITUTION_MATCH_NONE
+    lastInterpreted: '2024-02-26T12:47:27.271+00:00'
+    license: http://creativecommons.org/publicdomain/zero/1.0/legalcode
+    isSequenced: false
+    identifiers:
+    - identifier: 10.18730/1370T
+    media:
+    - references: https://cgngenis.wur.nl/accessiondetails/CGN00347
+    facts: []
+    relations: []
+    isInCluster: false
+    datasetID: NLD
+    geodeticDatum: WGS84
+    class: Liliopsida
+    countryCode: DE
+    recordedByIDs: []
+    identifiedByIDs: []
+    gbifRegion: EUROPE
+    country: Germany
+    publishedByGbifRegion: EUROPE
+    identifier: 10.18730/1370T
+    catalogNumber: CGN00347
+    vernacularName: barley
+    scientificNameID: Hordeum vulgare subsp. vulgare L.
+    institutionCode: NLD037
+    gbifID: '4525988610'
+    occurrenceID: 10.18730/1370T
+  - key: 4525988622
+    datasetKey: 85796928-f762-11e1-a439-00145eb45e9a
+    publishingOrgKey: efc2ae40-9880-11da-89b4-b8a03c50a862
+    installationKey: 97dfec69-b198-43ba-a8fa-c5edbc04e324
+    hostingOrganizationKey: cace8d10-2646-11d8-a2da-b8a03c50a862
+    publishingCountry: NL
+    protocol: EML
+    lastCrawled: '2024-02-26T11:40:15.213+00:00'
+    lastParsed: '2024-02-26T12:47:27.269+00:00'
+    crawlId: 364
+    extensions:
+      http://purl.org/germplasm/germplasmTerm#GermplasmAccession:
+      - http://purl.org/germplasm/germplasmTerm#germplasmID: CGN00348
+        http://purl.org/germplasm/germplasmTerm#purdyPedigree: Fida//Triple Awn Lemma/Aurore
+        http://purl.org/germplasm/germplasmTerm#storageCondition: '-20'
+        http://purl.org/germplasm/germplasmTerm#biologicalStatus: '400'
+        http://purl.org/germplasm/germplasmTerm#germplasmIdentifier: CGN00348
+        http://purl.org/germplasm/germplasmTerm#safetyDuplicationInstituteID: DEU146
+        http://purl.org/germplasm/germplasmTerm#ancestralData: Fida//Triple Awn Lemma/Aurore
+        http://purl.org/germplasm/germplasmTerm#mlsStatus: '1'
+        http://www.w3.org/2003/01/geo/wgs84_pos#lat: '53'
+        http://www.w3.org/2003/01/geo/wgs84_pos#long: '13'
+        http://purl.org/germplasm/germplasmTerm#donorInstituteID: NLD078
+    basisOfRecord: LIVING_SPECIMEN
+    occurrenceStatus: PRESENT
+    taxonKey: 4932619
+    kingdomKey: 6
+    phylumKey: 7707728
+    classKey: 196
+    orderKey: 1369
+    familyKey: 3073
+    genusKey: 2706050
+    speciesKey: 2706056
+    acceptedTaxonKey: 4932619
+    scientificName: Hordeum vulgare subsp. vulgare
+    acceptedScientificName: Hordeum vulgare subsp. vulgare
+    kingdom: Plantae
+    phylum: Tracheophyta
+    order: Poales
+    family: Poaceae
+    genus: Hordeum
+    species: Hordeum vulgare
+    genericName: Hordeum
+    specificEpithet: vulgare
+    infraspecificEpithet: vulgare
+    taxonRank: SUBSPECIES
+    taxonomicStatus: ACCEPTED
+    decimalLatitude: 53.0
+    decimalLongitude: 13.0
+    continent: EUROPE
+    gadm:
+      level0:
+        gid: DEU
+        name: Germany
+      level1:
+        gid: DEU.4_1
+        name: Brandenburg
+      level2:
+        gid: DEU.4.12_1
+        name: Ostprignitz-Ruppin
+      level3:
+        gid: DEU.4.12.4_1
+        name: Lindow (Mark)
+    issues:
+    - COUNTRY_DERIVED_FROM_COORDINATES
+    - CONTINENT_DERIVED_FROM_COORDINATES
+    - TAXON_MATCH_SCIENTIFIC_NAME_ID_IGNORED
+    - INSTITUTION_MATCH_NONE
+    lastInterpreted: '2024-02-26T12:47:27.269+00:00'
+    license: http://creativecommons.org/publicdomain/zero/1.0/legalcode
+    isSequenced: false
+    identifiers:
+    - identifier: 10.18730/1371V
+    media:
+    - references: https://cgngenis.wur.nl/accessiondetails/CGN00348
+    facts: []
+    relations: []
+    isInCluster: false
+    datasetID: NLD
+    geodeticDatum: WGS84
+    class: Liliopsida
+    countryCode: DE
+    recordedByIDs: []
+    identifiedByIDs: []
+    gbifRegion: EUROPE
+    country: Germany
+    publishedByGbifRegion: EUROPE
+    identifier: 10.18730/1371V
+    catalogNumber: CGN00348
+    vernacularName: barley
+    scientificNameID: Hordeum vulgare subsp. vulgare L.
+    institutionCode: NLD037
+    gbifID: '4525988622'
+    occurrenceID: 10.18730/1371V
+  - key: 4525988749
+    datasetKey: 85796928-f762-11e1-a439-00145eb45e9a
+    publishingOrgKey: efc2ae40-9880-11da-89b4-b8a03c50a862
+    installationKey: 97dfec69-b198-43ba-a8fa-c5edbc04e324
+    hostingOrganizationKey: cace8d10-2646-11d8-a2da-b8a03c50a862
+    publishingCountry: NL
+    protocol: EML
+    lastCrawled: '2024-02-26T11:40:15.213+00:00'
+    lastParsed: '2024-02-26T12:47:27.289+00:00'
+    crawlId: 364
+    extensions:
+      http://purl.org/germplasm/germplasmTerm#GermplasmAccession:
+      - http://purl.org/germplasm/germplasmTerm#germplasmID: CGN00356
+        http://purl.org/germplasm/germplasmTerm#storageCondition: '-20'
+        http://purl.org/germplasm/germplasmTerm#germplasmIdentifier: CGN00356
+        http://purl.org/germplasm/germplasmTerm#safetyDuplicationInstituteID: DEU146
+        http://purl.org/germplasm/germplasmTerm#mlsStatus: '1'
+        http://www.w3.org/2003/01/geo/wgs84_pos#lat: '53'
+        http://www.w3.org/2003/01/geo/wgs84_pos#long: '13'
+        http://purl.org/germplasm/germplasmTerm#donorInstituteID: NLD078
+        http://purl.org/germplasm/germplasmTerm#breedingIdentifier: G 1 m.s.
+    basisOfRecord: LIVING_SPECIMEN
+    occurrenceStatus: PRESENT
+    taxonKey: 4932619
+    kingdomKey: 6
+    phylumKey: 7707728
+    classKey: 196
+    orderKey: 1369
+    familyKey: 3073
+    genusKey: 2706050
+    speciesKey: 2706056
+    acceptedTaxonKey: 4932619
+    scientificName: Hordeum vulgare subsp. vulgare
+    acceptedScientificName: Hordeum vulgare subsp. vulgare
+    kingdom: Plantae
+    phylum: Tracheophyta
+    order: Poales
+    family: Poaceae
+    genus: Hordeum
+    species: Hordeum vulgare
+    genericName: Hordeum
+    specificEpithet: vulgare
+    infraspecificEpithet: vulgare
+    taxonRank: SUBSPECIES
+    taxonomicStatus: ACCEPTED
+    decimalLatitude: 53.0
+    decimalLongitude: 13.0
+    continent: EUROPE
+    gadm:
+      level0:
+        gid: DEU
+        name: Germany
+      level1:
+        gid: DEU.4_1
+        name: Brandenburg
+      level2:
+        gid: DEU.4.12_1
+        name: Ostprignitz-Ruppin
+      level3:
+        gid: DEU.4.12.4_1
+        name: Lindow (Mark)
+    issues:
+    - COUNTRY_DERIVED_FROM_COORDINATES
+    - CONTINENT_DERIVED_FROM_COORDINATES
+    - TAXON_MATCH_SCIENTIFIC_NAME_ID_IGNORED
+    - INSTITUTION_MATCH_NONE
+    lastInterpreted: '2024-02-26T12:47:27.289+00:00'
+    license: http://creativecommons.org/publicdomain/zero/1.0/legalcode
+    isSequenced: false
+    identifiers:
+    - identifier: 10.18730/1379=
+    media:
+    - references: https://cgngenis.wur.nl/accessiondetails/CGN00356
+    facts: []
+    relations: []
+    isInCluster: false
+    datasetID: NLD
+    geodeticDatum: WGS84
+    class: Liliopsida
+    countryCode: DE
+    recordedByIDs: []
+    identifiedByIDs: []
+    gbifRegion: EUROPE
+    country: Germany
+    publishedByGbifRegion: EUROPE
+    identifier: 10.18730/1379=
+    catalogNumber: CGN00356
+    vernacularName: barley
+    scientificNameID: Hordeum vulgare subsp. vulgare L.
+    institutionCode: NLD037
+    gbifID: '4525988749'
+    occurrenceID: 10.18730/1379=
+  - key: 4525989204
+    datasetKey: 85796928-f762-11e1-a439-00145eb45e9a
+    publishingOrgKey: efc2ae40-9880-11da-89b4-b8a03c50a862
+    installationKey: 97dfec69-b198-43ba-a8fa-c5edbc04e324
+    hostingOrganizationKey: cace8d10-2646-11d8-a2da-b8a03c50a862
+    publishingCountry: NL
+    protocol: EML
+    lastCrawled: '2024-02-26T11:40:15.213+00:00'
+    lastParsed: '2024-02-26T12:47:27.359+00:00'
+    crawlId: 364
+    extensions:
+      http://purl.org/germplasm/germplasmTerm#GermplasmAccession:
+      - http://purl.org/germplasm/germplasmTerm#germplasmID: CGN00364
+        http://purl.org/germplasm/germplasmTerm#storageCondition: '-20'
+        http://purl.org/germplasm/germplasmTerm#germplasmIdentifier: CGN00364
+        http://purl.org/germplasm/germplasmTerm#safetyDuplicationInstituteID: DEU146
+        http://purl.org/germplasm/germplasmTerm#mlsStatus: '1'
+        http://www.w3.org/2003/01/geo/wgs84_pos#lat: '53'
+        http://www.w3.org/2003/01/geo/wgs84_pos#long: '13'
+        http://purl.org/germplasm/germplasmTerm#donorInstituteID: NLD078
+        http://purl.org/germplasm/germplasmTerm#breedingIdentifier: Emilio Mariani
+    basisOfRecord: LIVING_SPECIMEN
+    occurrenceStatus: PRESENT
+    taxonKey: 4932619
+    kingdomKey: 6
+    phylumKey: 7707728
+    classKey: 196
+    orderKey: 1369
+    familyKey: 3073
+    genusKey: 2706050
+    speciesKey: 2706056
+    acceptedTaxonKey: 4932619
+    scientificName: Hordeum vulgare subsp. vulgare
+    acceptedScientificName: Hordeum vulgare subsp. vulgare
+    kingdom: Plantae
+    phylum: Tracheophyta
+    order: Poales
+    family: Poaceae
+    genus: Hordeum
+    species: Hordeum vulgare
+    genericName: Hordeum
+    specificEpithet: vulgare
+    infraspecificEpithet: vulgare
+    taxonRank: SUBSPECIES
+    taxonomicStatus: ACCEPTED
+    decimalLatitude: 53.0
+    decimalLongitude: 13.0
+    continent: EUROPE
+    gadm:
+      level0:
+        gid: DEU
+        name: Germany
+      level1:
+        gid: DEU.4_1
+        name: Brandenburg
+      level2:
+        gid: DEU.4.12_1
+        name: Ostprignitz-Ruppin
+      level3:
+        gid: DEU.4.12.4_1
+        name: Lindow (Mark)
+    issues:
+    - COUNTRY_DERIVED_FROM_COORDINATES
+    - CONTINENT_DERIVED_FROM_COORDINATES
+    - TAXON_MATCH_SCIENTIFIC_NAME_ID_IGNORED
+    - INSTITUTION_MATCH_NONE
+    lastInterpreted: '2024-02-26T12:47:27.359+00:00'
+    license: http://creativecommons.org/publicdomain/zero/1.0/legalcode
+    isSequenced: false
+    identifiers:
+    - identifier: 10.18730/137H6
+    media:
+    - references: https://cgngenis.wur.nl/accessiondetails/CGN00364
+    facts: []
+    relations: []
+    isInCluster: false
+    datasetID: NLD
+    geodeticDatum: WGS84
+    class: Liliopsida
+    countryCode: DE
+    recordedByIDs: []
+    identifiedByIDs: []
+    gbifRegion: EUROPE
+    country: Germany
+    publishedByGbifRegion: EUROPE
+    identifier: 10.18730/137H6
+    catalogNumber: CGN00364
+    vernacularName: barley
+    scientificNameID: Hordeum vulgare subsp. vulgare L.
+    institutionCode: NLD037
+    gbifID: '4525989204'
+    occurrenceID: 10.18730/137H6
+  facets: []

--- a/test/config_test_geofunctions.yml
+++ b/test/config_test_geofunctions.yml
@@ -38,7 +38,59 @@ test_location:
       wheelchair: 'yes'
       tactile_paving: 'yes'   
       public_transport: platform
-
+  expected_location:
+    type: FeatureCollection
+    licence: "Data © OpenStreetMap contributors, ODbL 1.0. http://osm.org/copyright"
+    features:
+      - type: Feature
+        properties:
+          place_id: 132326216
+          osm_type: relation
+          osm_id: 13392159
+          place_rank: 30
+          category: railway
+          type: platform
+          importance: 9.99999999995449e-06
+          addresstype: railway
+          name: Berlin Hauptbahnhof (Tief)
+          display_name: "Berlin Hauptbahnhof (Tief), Invalidenstraße, Europacity, Moabit, Mitte, Berlin, 10557, Germany"
+          address:
+            railway: Berlin Hauptbahnhof (Tief)
+            road: Invalidenstraße
+            quarter: Europacity
+            suburb: Moabit
+            borough: Mitte
+            city: Berlin
+            ISO3166-2-lvl4: DE-BE
+            postcode: '10557'
+            country: Germany
+            country_code: de
+          extratags:
+            bin: 'yes'
+            area: 'yes'
+            bench: 'yes'
+            layer: "-2"
+            level: "-2"
+            train: 'yes'
+            location: underground
+            ref:IFOPT: de:11000:900003200:2
+            wheelchair: 'yes'
+            tactile_paving: 'yes'
+            public_transport: platform
+          namedetails:
+            ref: "3;4"
+            name: Berlin Hauptbahnhof (Tief)
+            name:de: Berlin Hauptbahnhof (Tief)
+        bbox:
+          - 13.3678092
+          - 52.5234726
+          - 13.3704283
+          - 52.5270488
+        geometry:
+          type: Point
+          coordinates:
+            - 13.368987558281562
+            - 52.5254487
 
 test_wetdry:
   lat_dry: 52.5240
@@ -47,5 +99,6 @@ test_wetdry:
   lon_oce: 0.0
   lat_lake: 47.57983
   lon_lake: 9.47596
+
 
   

--- a/test/config_test_geofunctions.yml
+++ b/test/config_test_geofunctions.yml
@@ -3,9 +3,9 @@ test_location:
   lon: 13.3700
   closest_shore_distance: 143240.00374445764
   elevation: 36.0
-  lat_land_use: 52.5240
+  lat_land_use: 53.5240
   lon_land_use: 14.3700  
-  current_land_use: 'forest'
+  current_land_use: 'meadow'
   soil: 'Cambisols'
   expected_address:
     railway: Berlin Hauptbahnhof (Tief)

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -8,3 +8,4 @@ markers =
     hazard:     special test for test_filter_events_within_square (where extra file to download is needed: pend-gdis-1960-2018-disasterlocations.csv)
     economic:   economical functions (economic_functions.py)
     climate:    climate functions (climate_functions.py)
+    mock_request: replace test with HTTP request to mock requests, good to use with: -m "not request"

--- a/test/test_environmental_functions.py
+++ b/test/test_environmental_functions.py
@@ -15,6 +15,7 @@ import warnings
 import sys
 import os
 import requests
+import requests_mock
 import pandas as pd
 import matplotlib.pyplot as plt
 
@@ -54,7 +55,7 @@ def config_test():
         config_data = yaml.safe_load(file)
     return config_data
 
-#config_env = config_data
+#config_test = config_data
 
 @pytest.fixture
 def latlon(config_test):
@@ -74,6 +75,20 @@ def test_fetch_biodiversity(config_test, expected_biodiv):
     biodiv = fetch_biodiversity(round(lat), round(lon))
     assert biodiv == expected_biodiv, f"error in fetch_biodiversity, point({lat},{lon})"
 
+#test with mock request 
+@pytest.mark.mock_request
+@pytest.mark.env
+def test_mock_fetch_biodiversity(config_test, expected_biodiv, requests_mock):
+    lat, lon = config_test['test_location']['lat'], config_test['test_location']['lon']
+    
+    mock_url = "https://api.gbif.org/v1/occurrence/search"
+    mock_response = config_test['expected_biodiv']
+
+    requests_mock.get(mock_url, json=mock_response)
+
+    biodiv = fetch_biodiversity(round(lat), round(lon))
+    assert biodiv == expected_biodiv, f"error in fetch_biodiversity, point({lat},{lon})"    
+    
  #----------------------------- Test filter_events_within_square
 def are_dataframes_equal(df1, df2, tol=1e-6):
     """

--- a/test/test_geofunctions.py
+++ b/test/test_geofunctions.py
@@ -170,12 +170,28 @@ def test_where_is_point(config_geo, config_main):
     os.chdir('test')
 
 #--------------------------------   get_elevation_from_api  
+#test with request to api
 @pytest.mark.request
 def test_get_elevation_from_api(config_geo):
     lat, lon = config_geo['test_location']['lat'], config_geo['test_location']['lon']
     elevation = get_elevation_from_api(lat, lon)
     assert elevation == config_geo['test_location']['elevation'], f"error in elevation at point lat={lat}, lon={lon}"    
-    
+#test with mock request 
+@pytest.mark.mock_request
+def test_get_elevation_from_api(config_geo, requests_mock):
+    lat, lon = config_geo['test_location']['lat'], config_geo['test_location']['lon']
+    exp_elevation = config_geo['test_location']['elevation']
+    mock_url = f"https://api.opentopodata.org/v1/etopo1?locations={lat},{lon}"
+    mock_response ={'results': [{'dataset': 'etopo1',
+                    'elevation': exp_elevation,
+                    'location': {'lat': lat, 'lng': lon}}],
+                    'status': 'OK'}    
+
+    requests_mock.get(mock_url, json=mock_response)
+
+    elevation = get_elevation_from_api(lat, lon)
+    assert elevation == exp_elevation, f"error in elevation at point lat={lat}, lon={lon}"    
+     
 #--------------------------------   test_fetch_land_use  
 @pytest.mark.request
 def test_fetch_land_use(config_geo):


### PR DESCRIPTION
Add Test Functions with API Mocks. introduces test functions that use mocks to simulate API requests. Use the following commands to control test execution:
    `pytest -m "not request"`: Runs tests with local data and mocks, avoiding real API requests.
    `pytest -m "not mock_request"`: Runs tests with local data and actual API requests, avoiding mocks.

Workflow Update:
    In the workflows/ directory:

`    pytest -m "not local_data and not request"`

This command excludes tests that require local data or make API requests.

After merging PR #69, data downloading can be integrated into workflows.

!!! **fetch_biodiversity** was modified to avoid random output due to "**set**"

