### PR TITLE
remove unnecessary loading of config file

### DIFF
--- a/src/climsight/rag.py
+++ b/src/climsight/rag.py
@@ -22,10 +22,6 @@ logging.basicConfig(
    datefmt='%Y-%m-%d %H:%M:%S'
 )
 
-# Load config
-config_path = os.getenv('CONFIG_PATH', 'config.yml')
-with open(config_path, 'r') as file:
-    config = yaml.safe_load(file)
 
 def get_folder_name(rag_db_path):
     """


### PR DESCRIPTION
Removed lines 25-28 in rag.py :
# Load config
config_path = os.getenv('CONFIG_PATH', 'config.yml')
with open(config_path, 'r') as file:
    config = yaml.safe_load(file)