### PR TITLE
Update climsight_engine.py

### DIFF
--- a/src/climsight/climsight_engine.py
+++ b/src/climsight/climsight_engine.py
@@ -908,7 +908,7 @@ def agent_llm_request(content_message, input_params, config, api_key, stream_han
               
         chain = (
              intro_prompt
-             | llm_intro.with_structured_output(routeResponse)
+             | llm_intro.with_structured_output(routeResponse, method="function_calling")
          )
         # Pass the dictionary to invoke
         input = {"user_text": state.user}


### PR DESCRIPTION
Fix OpenAI structured output compatibility issue

This patch addresses an error that occurs in newer versions of langchain-openai (0.3+) when using structured output with Pydantic models that have default values. Starting with langchain-openai 0.3, the default method for structured output changed to use OpenAI's native format, which doesn't permit default values in schemas.

The fix explicitly sets method="function_calling" when using with_structured_output() to maintain compatibility across different versions of the library. This ensures the code works for both older setups (0.2.x) and newer ones (0.3.x+).

Error fixed:
"Invalid schema for response_format 'routeResponse': In context=('properties', 'final_answer'), 'default' is not permitted."