### PR TITLE
change structure for Embeding models calls , introduce Aitta embeding

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -55,9 +55,22 @@ ecocrop:
     data_path: "./data/ecocrop/ecocrop_database/"
 rag_settings:
     rag_activated: True
-    embedding_model: "text-embedding-3-large"
-    chroma_path_ipcc: "rag_db/ipcc_reports"
-    chroma_path_general: "rag_db/general_reports"
+    # Which embedding backend to use: openai, aitta, mistral, etc.
+    embedding_model_type: "openai"  # options: openai, aitta, mistral
+    # Embedding model name for each backend
+    embedding_model_openai: "text-embedding-3-large"
+    embedding_model_aitta: "lightonai/modernbert-embed-large"
+    # Add more as needed, e.g.:
+    # embedding_model_mistral: "mistral-embed-xyz"
+    # Chroma DB paths for each backend
+    chroma_path_ipcc_openai: "rag_db/ipcc_reports_openai"
+    chroma_path_ipcc_aitta: "rag_db/ipcc_reports_aitta"
+    # chroma_path_ipcc_mistral: "rag_db/ipcc_reports_mistral"
+    chroma_path_general_openai: "rag_db/general_reports_openai"
+    chroma_path_general_aitta: "rag_db/general_reports_aitta"
+    # chroma_path_general_mistral: "rag_db/general_reports_mistral"
+    # AITTA configuration for open models (optional, only needed for aitta)
+    aitta_url: "https://api-climatedt-aitta.2.rahtiapp.fi"
     document_path: './data/general_reports/' # or ipcc_text_reports
     chunk_size: 2000
     chunk_overlap: 200
@@ -140,14 +153,14 @@ system_role_new: |
 
   ### QUANTITATIVE-PRECISION RULES
   - **Every numeric value must name its reference** (month, season, decade, scenario label, baseline), e.g.  
-      “In July the mean temperature rises by …°C relative to …”  
+      "In July the mean temperature rises by …°C relative to …"  
   - Avoid vague phrases like *consistent trend, more variable, significant shift* **unless** the exact magnitude (unit or %) appears in the same sentence.  
   - Words such as *doubled, halved, dramatic, substantial* are permitted only when followed by the correct factor or percentage from the data.
 
   ### BEHAVIOUR RULES
   - Produce only the report. No greetings, apologies, or meta commentary.  
-  - Never begin with “Sure”, “Okay”, “Here is”, etc.  
-  - Write in third person; avoid “I” and “you”.  
+  - Never begin with "Sure", "Okay", "Here is", etc.  
+  - Write in third person; avoid "I" and "you".  
   - Cite IPCC or policy material inline as *(IPCC AR six, Working-Group two, Section twelve-point-four)*.  
   - Do not use level-1 or level-2 Markdown headings.  
   - Length: unrestricted—include all necessary detail.

--- a/src/climsight/climsight.py
+++ b/src/climsight/climsight.py
@@ -50,9 +50,7 @@ try:
    end_year = config['end_year']
    system_role = config['system_role']
    rag_settings = config['rag_settings']
-   embedding_model = rag_settings['embedding_model']
-   chroma_path_ipcc = rag_settings['chroma_path_ipcc']
-   chroma_path_general = rag_settings['chroma_path_general']
+   embedding_model_type = rag_settings['embedding_model_type']
    document_path = rag_settings['document_path']
    chunk_size = rag_settings['chunk_size']
    chunk_overlap = rag_settings['chunk_overlap']
@@ -62,8 +60,6 @@ try:
 except KeyError as e:
    logging.error(f"Missing configuration key: {e}")
    raise RuntimeError(f"Missing configuration key: {e}")
-
-chroma_path = [chroma_path_ipcc, chroma_path_general]
 
 references = {'references': {}, 'used': []}
 # reading references file
@@ -78,6 +74,6 @@ if not references:
       logging.error(f"An error occurred while reading the file: {references_path}")
       raise RuntimeError(f"An error occurred while reading the file: {references_path}") from e
 if not terminal_call:
-   run_streamlit(config, skip_llm_call=skip_llm_call, rag_activated=rag_activated, embedding_model=embedding_model, chroma_path=chroma_path, references=references)
+   run_streamlit(config, skip_llm_call=skip_llm_call, rag_activated=rag_activated, references=references)
 else:   
-   output = run_terminal(config, skip_llm_call=skip_llm_call, embedding_model=embedding_model, chroma_path=chroma_path, references=references)
+   output = run_terminal(config, skip_llm_call=skip_llm_call, references=references)

--- a/src/climsight/climsight_engine.py
+++ b/src/climsight/climsight_engine.py
@@ -951,11 +951,11 @@ def agent_llm_request(content_message, input_params, config, api_key, api_key_lo
 
         1. **FINISH:** If the question is unrelated to ClimSight's purpose or is a simple inquiry outside your primary objectives,
         you can choose to finish the conversation by selecting FINISH and providing a concise answer. Examples of unrelated or simple questions:
-        - “Hi”
-        - “How are you?”
-        - “Who are you?”
-        - “Write an essay on the history of trains.”
-        - “Translate some text for me.”
+        - "Hi"
+        - "How are you?"
+        - "Who are you?"
+        - "Write an essay on the history of trains."
+        - "Translate some text for me."
 
         2. **CONTINUE:** For all other cases, if the question relates to climate or location, select CONTINUE to proceed,
         which will prompt other agents to address the user's question. Note that the specific location may not be mentioned in the user's initial question, 
@@ -1097,12 +1097,16 @@ def agent_llm_request(content_message, input_params, config, api_key, api_key_lo
         for msg in prompt_messages:
             role = getattr(msg, "type", getattr(msg, "role", ""))
             chat_prompt_text += f"{role.capitalize()}: {msg.content}\n"
-            
+        
+        #print("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")    
+        #print("chat_prompt_text: ", chat_prompt_text)
+        #print("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")    
         return {
             'final_answer': output_content, 
             'input_params': state.input_params, 
             'content_message': state.content_message,
-            'combine_agent_prompt_text': chat_prompt_text}
+            'combine_agent_prompt_text': chat_prompt_text
+        }
     
     def route_fromintro(state: AgentState) -> Sequence[str]:
         output = []
@@ -1173,7 +1177,7 @@ def agent_llm_request(content_message, input_params, config, api_key, api_key_lo
 
     input_params = output['input_params']
     content_message = output['content_message']
-    combine_agent_prompt_text = output['combine_agent_prompt_text']
+    combine_agent_prompt_text = output.get('combine_agent_prompt_text', '')
     
     stream_handler.update_progress("Analysis complete!")
     

--- a/src/climsight/embedding_utils.py
+++ b/src/climsight/embedding_utils.py
@@ -1,0 +1,72 @@
+import os
+import logging
+from typing import Optional
+from langchain_openai.embeddings import OpenAIEmbeddings
+
+logger = logging.getLogger(__name__)
+
+def create_embeddings(
+    model_type: str,
+    embedding_model: str,
+    openai_api_key: Optional[str] = None,
+    aitta_api_key: Optional[str] = None,
+    aitta_url: Optional[str] = None,
+    model_name: Optional[str] = None
+) -> OpenAIEmbeddings:
+    """
+    Creates an embedding model instance based on the configuration.
+    
+    Args:
+        model_type (str): Which backend to use ('openai', 'aitta', ...)
+        embedding_model (str): The embedding model name or type
+        openai_api_key (str, optional): OpenAI API key for OpenAI models
+        aitta_api_key (str, optional): AITTA API key for open models
+        aitta_url (str, optional): AITTA API URL for open models
+        model_name (str, optional): Specific model name for open models
+        
+    Returns:
+        OpenAIEmbeddings: Configured embedding model instance
+        
+    Raises:
+        ValueError: If required parameters are missing or configuration is invalid
+    """
+    
+    if model_type == 'openai':
+        if not openai_api_key:
+            raise ValueError("OPENAI_API_KEY is required for OpenAI models")
+        return OpenAIEmbeddings(
+            api_key=openai_api_key,  # type: ignore
+            model=embedding_model
+        )
+    elif model_type == 'aitta':
+        if not aitta_api_key:
+            raise ValueError("AITTA_API_KEY is required for aitta models")
+        if not aitta_url:
+            raise ValueError("AITTA URL is required for aitta models")
+        if not model_name:
+            model_name = embedding_model
+            
+        try:
+            # Import aitta_client only when needed
+            from aitta_client import Model, Client
+            from aitta_client.authentication import APIKeyAccessTokenSource
+            
+            client = Client(aitta_url, APIKeyAccessTokenSource(aitta_api_key, aitta_url))
+            model = Model.load(model_name, client)
+            
+            return OpenAIEmbeddings(
+                model=model.id,
+                api_key=client.access_token_source.get_access_token(),  # type: ignore
+                base_url=model.openai_api_url,
+                tiktoken_enabled=False
+            )
+        except ImportError:
+            raise ImportError("aitta_client is required for aitta models. Install with: pip install aitta-client")
+        except Exception as e:
+            logger.error(f"Failed to create aitta model embeddings: {e}")
+            raise ValueError(f"Failed to create aitta model embeddings: {e}")
+    # elif model_type == 'mistral':
+    #     # Add logic for mistral here
+    #     pass
+    else:
+        raise ValueError(f"Unknown model_type: {model_type}") 

--- a/src/climsight/evaluation.py
+++ b/src/climsight/evaluation.py
@@ -253,13 +253,6 @@ def request_answers_from_climsight(question_answers, llm_model_request, series =
         user_message = user_message + ' ' + question_answers[series][qa_indx]['question']
         lon = question_answers[series][qa_indx].get('lon', 13.37)
         lat = question_answers[series][qa_indx].get('lat', 52.524)
-
-        rag_settings = config['rag_settings']
-        embedding_model = rag_settings['embedding_model']
-        chroma_path_ipcc = rag_settings['chroma_path_ipcc']
-        chroma_path_general = rag_settings['chroma_path_general'] 
-        chroma_path = [chroma_path_ipcc, chroma_path_general]
-        
         #set LLM to be used for the Climsight 
         config['model_name_combine_agent']=llm_model_request
 
@@ -269,9 +262,7 @@ def request_answers_from_climsight(question_answers, llm_model_request, series =
                             user_message=user_message, 
                             show_add_info='n', 
                             verbose=False, 
-                            rag_activated=True, 
-                            embedding_model=embedding_model, 
-                            chroma_path=chroma_path)
+                            rag_activated=True)
    
         output_answers.append(output)
 

--- a/src/climsight/smart_agent.py
+++ b/src/climsight/smart_agent.py
@@ -27,8 +27,11 @@ from langchain.document_loaders import WikipediaLoader
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_openai import ChatOpenAI
 
-from aitta_client import Model, Client
-from aitta_client.authentication import APIKeyAccessTokenSource
+try:
+    from aitta_client import Model, Client
+    from aitta_client.authentication import APIKeyAccessTokenSource
+except:
+    pass
 
 # Import AgentState from climsight_classes
 from climsight_classes import AgentState

--- a/src/climsight/streamlit_interface.py
+++ b/src/climsight/streamlit_interface.py
@@ -13,19 +13,20 @@ from streamlit_folium import st_folium
 import folium
 
 # rag
-from rag import load_rag 
+from rag import load_rag
 
 # climsight modules
 from stream_handler import StreamHandler
 from data_container import DataContainer
 from climsight_engine import normalize_longitude, llm_request, forming_request, location_request
 from extract_climatedata_functions import plot_climate_data
+from embedding_utils import create_embeddings
 
 logger = logging.getLogger(__name__)
 
 data_pocket = DataContainer()
 
-def run_streamlit(config, api_key='', skip_llm_call=False, rag_activated=True, embedding_model='', chroma_path='', references=None):
+def run_streamlit(config, api_key='', skip_llm_call=False, rag_activated=True, references=None):
     """
     Runs the Streamlit interface for ClimSight, allowing users to interact with the system.
     Args:
@@ -33,8 +34,6 @@ def run_streamlit(config, api_key='', skip_llm_call=False, rag_activated=True, e
         - api_key (string): API Key, default is an empty string.
         - skip_llm_call (bool): If True - skip final call to LLM
         - rag_activated (bool): whether or not to include the text based rag
-        - embedding_model (str): embedding model to be used for loading the Chroma database.
-        - chroma_path (str): Path where the Chroma database is stored.
         - references (dict): References for the data used in the analysis.
     Returns:
         None
@@ -157,11 +156,9 @@ def run_streamlit(config, api_key='', skip_llm_call=False, rag_activated=True, e
             # for the moment. Just making a note here for any potential problems that might arise later one. 
             # Load RAG
             if not skip_llm_call and rag_activated:
-                chroma_path_ipcc = chroma_path[0]
-                chroma_path_general = chroma_path[1]
                 try:
                     logger.info("RAG is activated and skipllmcall is False. Loading IPCC RAG database...")
-                    ipcc_rag_ready, ipcc_rag_db = load_rag(embedding_model, chroma_path_ipcc, api_key) # load the RAG database 
+                    ipcc_rag_ready, ipcc_rag_db = load_rag(config, openai_api_key=api_key, db_type='ipcc')
                 except Exception as e:
                     st.error(f"Loading of the IPCC RAG database failed unexpectedly, please check the logs. {e}")
                     logger.warning(f"IPCC RAG database initialization skipped or failed: {e}")
@@ -169,7 +166,7 @@ def run_streamlit(config, api_key='', skip_llm_call=False, rag_activated=True, e
                     ipcc_rag_db = None
                 try:
                     logger.info("RAG is activated and skipllmcall is False. Loading general RAG database...")
-                    general_rag_ready, general_rag_db = load_rag(embedding_model, chroma_path_general, api_key) # load the RAG database 
+                    general_rag_ready, general_rag_db = load_rag(config, openai_api_key=api_key, db_type='general')
                 except Exception as e:
                     st.error(f"Loading of the (general) RAG database failed unexpectedly, please check the logs. {e}")
                     logger.warning(f"(General) RAG database initialization skipped or failed: {e}")

--- a/src/climsight/terminal_interface.py
+++ b/src/climsight/terminal_interface.py
@@ -32,7 +32,7 @@ def print_verbose(verbose, message):
     if verbose:
         print(message)  
 
-def run_terminal(config, api_key='', skip_llm_call=False, lon=None, lat=None, user_message='', show_add_info='',verbose=True, rag_activated=None, embedding_model='', chroma_path='', references=None):
+def run_terminal(config, api_key='', skip_llm_call=False, lon=None, lat=None, user_message='', show_add_info='',verbose=True, rag_activated=None, references=None):
     '''
         Inputs:
         - config (dict): Configuration, default is an empty dictionary.   
@@ -44,8 +44,6 @@ def run_terminal(config, api_key='', skip_llm_call=False, lon=None, lat=None, us
         - show_add_info (string): If 'y' - show additional information, if 'n' - do not show additional information. default ''
         - verbose (bool): If True - print additional information, if False - do not print additional information (used for loop request). default True
         - rag_activated (bool): whether or not to include the text based rag
-        - embedding_model (str): embedding model to be used for loading the Chroma database.
-        - chroma_path (str): Path where the Chroma database is stored.
         Output:
         - output (string): Output from the LLM.
     '''      
@@ -147,18 +145,16 @@ def run_terminal(config, api_key='', skip_llm_call=False, lon=None, lat=None, us
 
     # RAG
     if not skip_llm_call and rag_activated:
-        chroma_path_ipcc = chroma_path[0]
-        chroma_path_general = chroma_path[1]
         try:
             logger.info("RAG is activated and skipllmcall is False. Loading IPCC RAG database...")
-            ipcc_rag_ready, ipcc_rag_db = load_rag(embedding_model, chroma_path_ipcc, api_key) # load the RAG database 
+            ipcc_rag_ready, ipcc_rag_db = load_rag(config, openai_api_key=api_key, db_type='ipcc')
         except Exception as e:
             logger.warning(f"IPCC RAG database initialization skipped or failed: {e}")
             rag_ready = False
             rag_db = None
         try:
             logger.info("RAG is activated and skipllmcall is False. Loading general RAG database...")
-            general_rag_ready, general_rag_db = load_rag(embedding_model, chroma_path_general, api_key) # load the RAG database 
+            general_rag_ready, general_rag_db = load_rag(config, openai_api_key=api_key, db_type='general')
         except Exception as e:
             logger.warning(f"(General) RAG database initialization skipped or failed: {e}")
             general_rag_ready = False

--- a/test/test_rag.py
+++ b/test/test_rag.py
@@ -13,9 +13,7 @@ if module_dir not in sys.path:
 os.environ['CONFIG_PATH'] = os.path.abspath('../config.yml')
 
 # Import module functions
-from rag import (
-    load_rag
-)
+from rag import load_rag
 
 from langchain_core.documents import Document
 
@@ -23,7 +21,7 @@ from langchain_core.documents import Document
 class TestLoadRag(unittest.TestCase):
     @patch('rag.is_valid_rag_db', return_value=True) # simulate case where db is valid
     @patch('rag.Chroma')
-    @patch('rag.OpenAIEmbeddings')
+    @patch('embedding_utils.OpenAIEmbeddings')
     def test_load_rag_when_ready(self, mock_openai_embeddings, mock_chroma, mock_is_valid_rag_db):
         # Mock the embeddings and chroma instances
         mock_embedding_instance = MagicMock()
@@ -32,13 +30,20 @@ class TestLoadRag(unittest.TestCase):
         mock_chroma.return_value = mock_chroma_instance
 
         # Call the function with the mocks
-        config = {...}  # minimal config dict for test
+        config = {
+            "rag_settings": {
+                "embedding_model_type": "openai",
+                "embedding_model_openai": "text-embedding-3-large",
+                "chroma_path_ipcc_openai": "test_chroma_path",
+                # Add any other keys your code expects
+            }
+        }
         rag_ready, rag_db = load_rag(config, openai_api_key='test_key', db_type='ipcc')
 
         # Assert that OpenAIEmbeddings and Chroma were called when rag_ready is True
         self.assertTrue(rag_ready)
         self.assertIs(rag_db, mock_chroma_instance) # making sure that rag_db is exactly the mocked chroma instance
-        mock_openai_embeddings.assert_called_once_with(openai_api_key='test_key', model='text-embedding-3-large')
+        mock_openai_embeddings.assert_called_once_with(api_key='test_key', model='text-embedding-3-large')
         mock_chroma.assert_called_once_with(
             persist_directory='test_chroma_path',
             embedding_function=mock_embedding_instance,
@@ -48,7 +53,14 @@ class TestLoadRag(unittest.TestCase):
     @patch('rag.is_valid_rag_db', return_value=False) # simulate case where db is not valid
     def test_load_rag_when_not_ready(self, mock_is_valid_rag_db):
         # Call the function without valid RAG setup
-        config = {...}  # minimal config dict for test
+        config = {
+            "rag_settings": {
+                "embedding_model_type": "openai",
+                "embedding_model_openai": "text-embedding-3-large",
+                "chroma_path_ipcc_openai": "test_chroma_path",
+                # Add any other keys your code expects
+            }
+        }
         rag_ready, rag_db = load_rag(config, openai_api_key='test_key', db_type='ipcc')
 
         # Assertions for an invalid RAG database

--- a/test/test_rag.py
+++ b/test/test_rag.py
@@ -32,7 +32,8 @@ class TestLoadRag(unittest.TestCase):
         mock_chroma.return_value = mock_chroma_instance
 
         # Call the function with the mocks
-        rag_ready, rag_db = load_rag(embedding_model='text-embedding-3-large', chroma_path='test_chroma_path', openai_api_key='test_key')
+        config = {...}  # minimal config dict for test
+        rag_ready, rag_db = load_rag(config, openai_api_key='test_key', db_type='ipcc')
 
         # Assert that OpenAIEmbeddings and Chroma were called when rag_ready is True
         self.assertTrue(rag_ready)
@@ -47,7 +48,8 @@ class TestLoadRag(unittest.TestCase):
     @patch('rag.is_valid_rag_db', return_value=False) # simulate case where db is not valid
     def test_load_rag_when_not_ready(self, mock_is_valid_rag_db):
         # Call the function without valid RAG setup
-        rag_ready, rag_db = load_rag(embedding_model='text-embedding-3-large', chroma_path='test_chroma_path', openai_api_key='test_key')
+        config = {...}  # minimal config dict for test
+        rag_ready, rag_db = load_rag(config, openai_api_key='test_key', db_type='ipcc')
 
         # Assertions for an invalid RAG database
         self.assertFalse(rag_ready)


### PR DESCRIPTION
This PR refactors the RAG embedding model selection logic to support both OpenAI and open-source models (such as AITTA) in a configurable and extensible way. The configuration now allows specifying the embedding backend and model, and the codebase dynamically selects and instantiates the appropriate embedding model based on these settings. This enables seamless switching between OpenAI and open models for RAG workflows, and lays the groundwork for easy integration of additional backends in the future. The PR also updates the tests and mocks to match the new structure, ensuring robust coverage for both OpenAI and open model scenarios.